### PR TITLE
fix!: import.meta not supported, drop support of Node<14

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Server-side generation for Vite.
 
 > ℹ️ **Vite 2 is supported from `v0.2.x`, Vite 1's support is discontinued.**
 
+> ℹ️ **Need Node.js version >= 14**
+
 <pre>
 <b>npm i -D vite-ssg</b> <em>vue-router @vue/server-renderer @vue/compiler-sfc</em>
 </pre>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "license": "MIT",
   "funding": "https://github.com/sponsors/antfu",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/antfu/vite-ssg"

--- a/src/build.ts
+++ b/src/build.ts
@@ -39,7 +39,7 @@ export async function build({ script = 'sync', mock = false } = {}) {
 
   const ssrConfig: UserConfig = {
     esbuild: {
-      target: 'es2018',
+      target: 'es2020',
     },
     build: {
       ssr: true,

--- a/src/build.ts
+++ b/src/build.ts
@@ -78,7 +78,7 @@ export async function build({ script = 'sync', mock = false } = {}) {
 
   const { routes } = createApp(false)
   // ignore dynamic routes
-  const routesPathes = routes.map(i => i.path).filter(i => !i.includes(':'))
+  const routesPaths = routes.map(i => i.path).filter(i => !i.includes(':'))
 
   if (script && script !== 'sync')
     indexHTML = indexHTML.replace(/<script type="module" /g, `<script type="module" ${script} `)
@@ -92,7 +92,7 @@ export async function build({ script = 'sync', mock = false } = {}) {
 
   console.log('[vite-ssg] Rendering Pages...')
   await Promise.all(
-    routesPathes.map(async(route) => {
+    routesPaths.map(async(route) => {
       const { app, router } = createApp(false)
       router.push(route)
       await router.isReady()

--- a/src/build.ts
+++ b/src/build.ts
@@ -38,9 +38,6 @@ export async function build({ script = 'sync', mock = false } = {}) {
   const ssgOut = join(root, '.vite-ssg-dist')
 
   const ssrConfig: UserConfig = {
-    esbuild: {
-      target: 'es2020',
-    },
     build: {
       ssr: true,
       outDir: ssgOut,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "compilerOptions": {
     "module": "ESNext",
-    "target": "es2017",
-    "lib": ["ESNext", "DOM"],
+    "target": "es2020",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
     "esModuleInterop": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
#4 Change esbuild target to es2020 and add a notation on README.