### PR TITLE
feat: support nested routes

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -7,7 +7,7 @@ import { JSDOM } from 'jsdom'
 import { RollupOutput } from 'rollup'
 import { ViteSSGContext, ViteSSGOptions } from '../client'
 import { renderPreloadLinks } from './perloadlink'
-import { buildLog, collectRoutePaths, getSize } from './utils'
+import { buildLog, routesToPaths, getSize } from './utils'
 
 export interface Manifest {
   [key: string]: string[]
@@ -77,7 +77,7 @@ export async function build(cliOptions: ViteSSGOptions = {}) {
   const { routes } = createApp(false)
 
   const routesPaths = routes
-    ? collectRoutePaths(routes)
+    ? routesToPaths(routes)
     : ['/']
 
   indexHTML = rewriteScripts(indexHTML, script)

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -7,7 +7,7 @@ import { JSDOM } from 'jsdom'
 import { RollupOutput } from 'rollup'
 import { ViteSSGContext, ViteSSGOptions } from '../client'
 import { renderPreloadLinks } from './perloadlink'
-import { buildLog, getSize } from './utils'
+import { buildLog, collectRoutePaths, getSize } from './utils'
 
 export interface Manifest {
   [key: string]: string[]
@@ -76,24 +76,8 @@ export async function build(cliOptions: ViteSSGOptions = {}) {
 
   const { routes } = createApp(false)
 
-  // this function recursively extracts all paths from a given route
-  const pathsFromRoute = (prefix: string) => (route: any) => {
-    const paths = [
-      prefix ? `${prefix}/${route.path}` : route.path
-    ]
-
-    if (Array.isArray(route.children)) {
-      paths.push(...route.children.flatMap(pathsFromRoute(route.path)))
-    }
-
-    return paths
-  }
-
-  // ignore dynamic routes when rendering
   const routesPaths = routes
-    ? routes
-      .flatMap(pathsFromRoute(''))
-      .filter(i => i && !i.includes(':'))
+    ? collectRoutePaths(routes)
     : ['/']
 
   indexHTML = rewriteScripts(indexHTML, script)

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -8,7 +8,7 @@ export function getSize(str: string) {
   return `${(str.length / 1024).toFixed(2)}kb`
 }
 
-export function collectRoutePaths(routes: any[]) {
+export function routesToPaths(routes: any[]) {
   const pathsFromRoute = (prefix = '') => (route: any): string[] => {
     // include the prefix from the parent in this path
     const paths = [

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { RouteRecordRaw } from 'vue-router'
 
 export function buildLog(text: string, count?: number) {
   console.log(`\n${chalk.gray('[vite-ssg]')} ${chalk.yellow(text)}${count ? chalk.blue(` (${count})`) : ''}`)
@@ -8,8 +9,8 @@ export function getSize(str: string) {
   return `${(str.length / 1024).toFixed(2)}kb`
 }
 
-export function routesToPaths(routes: any[]) {
-  const pathsFromRoute = (prefix = '') => (route: any): string[] => {
+export function routesToPaths(routes: RouteRecordRaw[]) {
+  const pathsFromRoute = (prefix = '') => (route: RouteRecordRaw): string[] => {
     // include the prefix from the parent in this path
     const paths = [
       prefix ? `${prefix}/${route.path}` : route.path

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -7,3 +7,24 @@ export function buildLog(text: string, count?: number) {
 export function getSize(str: string) {
   return `${(str.length / 1024).toFixed(2)}kb`
 }
+
+export function collectRoutePaths(routes: any[]) {
+  const pathsFromRoute = (prefix: string) => (route: any): string[] => {
+    // include the prefix from the parent in this path
+    const paths = [
+      prefix ? `${prefix}/${route.path}` : route.path
+    ]
+
+    // if the route has children, recursively traverse those as well
+    if (Array.isArray(route.children)) {
+      paths.push(...route.children.flatMap(pathsFromRoute(route.path)))
+    }
+
+    return paths
+  }
+
+
+  return routes
+    .flatMap(pathsFromRoute(''))
+    .filter(i => !i.includes(':')) // ignore dynamic routes
+}

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -9,7 +9,7 @@ export function getSize(str: string) {
 }
 
 export function collectRoutePaths(routes: any[]) {
-  const pathsFromRoute = (prefix: string) => (route: any): string[] => {
+  const pathsFromRoute = (prefix = '') => (route: any): string[] => {
     // include the prefix from the parent in this path
     const paths = [
       prefix ? `${prefix}/${route.path}` : route.path
@@ -25,6 +25,6 @@ export function collectRoutePaths(routes: any[]) {
 
 
   return routes
-    .flatMap(pathsFromRoute(''))
+    .flatMap(pathsFromRoute())
     .filter(i => !i.includes(':')) // ignore dynamic routes
 }


### PR DESCRIPTION
Hey, this is something I've been using with my website for a while now,
but I thought this could benefit others too.
Currently Vite-ssg only considers top-level routes, I've added a function that recursively traverses the route tree.
Since I've been using this myself for a while now, I'm quite confident that it does not introduce any errors but you might wanna have a closer look :)
Cheers!