### PR TITLE
feat: option to disable @vueuse/head

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,6 @@
 import { createSSRApp, Component, createApp as createClientApp } from 'vue'
 import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router'
-import { createHead } from '@vueuse/head'
+import { createHead, Head } from '@vueuse/head'
 import { RouterOptions, ViteSSGContext, ViteSSGClientOptions } from '../types'
 import { ClientOnly } from './components/ClientOnly'
 
@@ -12,7 +12,10 @@ export function ViteSSG(
   fn?: (context: ViteSSGContext<true>) => void,
   options: ViteSSGClientOptions = {},
 ) {
-  const { registerComponents = true } = options
+  const {
+    registerComponents = true,
+    useHead = true,
+  } = options
   const isClient = typeof window !== 'undefined'
 
   function createApp(client = false) {
@@ -21,11 +24,12 @@ export function ViteSSG(
       : createSSRApp(App)
 
     let context: ViteSSGContext<true>
+    let head: Head | undefined
 
-    const head = createHead()
-
-    app.use(head)
-
+    if (useHead) {
+      head = createHead()
+      app.use(head)
+    }
 
     const router = createRouter({
       history: client ? createWebHistory() : createMemoryHistory(),

--- a/src/client/single-page.ts
+++ b/src/client/single-page.ts
@@ -1,5 +1,5 @@
 import { createSSRApp, Component, createApp as createClientApp } from 'vue'
-import { createHead } from '@vueuse/head'
+import { createHead, Head } from '@vueuse/head'
 import { ClientOnly } from './components/ClientOnly'
 import { ViteSSGClientOptions, ViteSSGContext } from '../types'
 
@@ -10,7 +10,10 @@ export function ViteSSG(
   fn?: (context: ViteSSGContext<false>) => void,
   options: ViteSSGClientOptions = {},
 ) {
-  const { registerComponents = true } = options
+  const {
+    registerComponents = true,
+    useHead = true,
+  } = options
   const isClient = typeof window !== 'undefined'
 
   function createApp(client = false) {
@@ -19,10 +22,12 @@ export function ViteSSG(
       : createSSRApp(App)
 
     let context: ViteSSGContext<false>
+    let head: Head | undefined
 
-    const head = createHead()
-
-    app.use(head)
+    if (useHead) {
+      head = createHead()
+      app.use(head)
+    }
 
     context = { app, head, isClient, router: undefined, routes: undefined }
 

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -114,7 +114,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
       renderPreloadLinks(jsdom.window.document, ctx.modules || new Set<string>(), ssrManifest)
 
       // render head
-      head && head.updateDOM(jsdom.window.document)
+      head?.updateDOM(jsdom.window.document)
 
       const html = jsdom.serialize()
       const transformed = (await onPageRendered?.(route, html)) || html

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -114,7 +114,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
       renderPreloadLinks(jsdom.window.document, ctx.modules || new Set<string>(), ssrManifest)
 
       // render head
-      head.updateDOM(jsdom.window.document)
+      head && head.updateDOM(jsdom.window.document)
 
       const html = jsdom.serialize()
       const transformed = (await onPageRendered?.(route, html)) || html

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,12 +62,13 @@ export interface ViteSSGContext<HasRouter extends boolean = true> {
   app: App<Element>
   router: HasRouter extends true ? Router : undefined
   routes: HasRouter extends true ? RouteRecordRaw[] : undefined
-  head: Head
+  head: Head | undefined
   isClient: boolean
 }
 
 export interface ViteSSGClientOptions {
   registerComponents?: boolean
+  useHead?: boolean
 }
 
 export type RouterOptions = PartialKeys<VueRouterOptions, 'history'>


### PR DESCRIPTION
Sometimes it can be useful to disable `@vueuse/head`. Especially for single-page website.

```js
export const createApp = ViteSSG(App, () => {}, {
  registerComponents: false,
  useHead: false
})
```