### PR TITLE
feat: Add the isWebHashHistory parameter to enable vue-router to use hash mode

### DIFF
--- a/examples/multiple-pages/src/main.ts
+++ b/examples/multiple-pages/src/main.ts
@@ -2,4 +2,4 @@ import { ViteSSG } from 'vite-ssg'
 import routes from 'pages-generated'
 import App from './App.vue'
 
-export const createApp = ViteSSG(App, { routes })
+export const createApp = ViteSSG(App, { isWebHashHistory: true, routes })

--- a/examples/multiple-pages/src/main.ts
+++ b/examples/multiple-pages/src/main.ts
@@ -2,4 +2,4 @@ import { ViteSSG } from 'vite-ssg'
 import routes from 'pages-generated'
 import App from './App.vue'
 
-export const createApp = ViteSSG(App, { isWebHashHistory: true, routes })
+export const createApp = ViteSSG(App, { mode: 'hash', routes })

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,14 +1,18 @@
 import { createSSRApp, Component, createApp as createClientApp } from 'vue'
-import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router'
+import { createMemoryHistory, createRouter, createWebHistory, createWebHashHistory } from 'vue-router'
 import { createHead, Head } from '@vueuse/head'
 import { RouterOptions, ViteSSGContext, ViteSSGClientOptions } from '../types'
 import { ClientOnly } from './components/ClientOnly'
 
 export * from '../types'
 
+type ExtRouterOptions = RouterOptions & {
+  isWebHashHistory: boolean
+}
+
 export function ViteSSG(
   App: Component,
-  routerOptions: RouterOptions,
+  routerOptions: ExtRouterOptions,
   fn?: (context: ViteSSGContext<true>) => void,
   options: ViteSSGClientOptions = {},
 ) {
@@ -30,8 +34,14 @@ export function ViteSSG(
       app.use(head)
     }
 
+    const { isWebHashHistory } = routerOptions
+
     const router = createRouter({
-      history: client ? createWebHistory() : createMemoryHistory(),
+      history: client
+        ? isWebHashHistory
+          ? createWebHashHistory()
+          : createWebHistory()
+        : createMemoryHistory(),
       ...routerOptions,
     })
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -6,13 +6,9 @@ import { ClientOnly } from './components/ClientOnly'
 
 export * from '../types'
 
-type ExtRouterOptions = RouterOptions & {
-  isWebHashHistory: boolean
-}
-
 export function ViteSSG(
   App: Component,
-  routerOptions: ExtRouterOptions,
+  routerOptions: RouterOptions,
   fn?: (context: ViteSSGContext<true>) => void,
   options: ViteSSGClientOptions = {},
 ) {
@@ -34,11 +30,9 @@ export function ViteSSG(
       app.use(head)
     }
 
-    const { isWebHashHistory } = routerOptions
-
     const router = createRouter({
       history: client
-        ? isWebHashHistory
+        ? routerOptions.mode === 'hash'
           ? createWebHashHistory(routerOptions.base)
           : createWebHistory(routerOptions.base)
         : createMemoryHistory(routerOptions.base),

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export interface ViteSSGClientOptions {
   useHead?: boolean
 }
 
-export type RouterOptions = PartialKeys<VueRouterOptions, 'history'> & { base?: string }
+export type RouterOptions = PartialKeys<VueRouterOptions, 'history'> & { base?: string; mode?: string }
 
 // extend vite.config.ts
 declare module 'vite' {


### PR DESCRIPTION
Add the `isWebHashHistory` parameter to enable `vue-router` to use `hash mode`.
```ts
// examples/multiple-pages/src/main.ts
export const createApp = ViteSSG(App, { isWebHashHistory: true, routes })
```