### PR TITLE
feat: add rootContainer option for app.mount

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,7 +15,7 @@ export function ViteSSG(
   const {
     registerComponents = true,
     useHead = true,
-    rootContainer = "#app",
+    rootContainer = '#app',
   } = options
   const isClient = typeof window !== 'undefined'
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,6 +15,7 @@ export function ViteSSG(
   const {
     registerComponents = true,
     useHead = true,
+    rootContainer = "#app",
   } = options
   const isClient = typeof window !== 'undefined'
 
@@ -56,7 +57,7 @@ export function ViteSSG(
 
     // wait until page component is fetched before mounting
     router.isReady().then(() => {
-      app.mount('#app', true)
+      app.mount(rootContainer, true)
     })
   }
 

--- a/src/client/single-page.ts
+++ b/src/client/single-page.ts
@@ -13,6 +13,7 @@ export function ViteSSG(
   const {
     registerComponents = true,
     useHead = true,
+    rootContainer = "#app",
   } = options
   const isClient = typeof window !== 'undefined'
 
@@ -40,7 +41,7 @@ export function ViteSSG(
 
   if (isClient) {
     const { app } = createApp(true)
-    app.mount('#app', true)
+    app.mount(rootContainer, true)
   }
 
   return createApp

--- a/src/client/single-page.ts
+++ b/src/client/single-page.ts
@@ -13,7 +13,7 @@ export function ViteSSG(
   const {
     registerComponents = true,
     useHead = true,
-    rootContainer = "#app",
+    rootContainer = '#app',
   } = options
   const isClient = typeof window !== 'undefined'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export interface ViteSSGContext<HasRouter extends boolean = true> {
 export interface ViteSSGClientOptions {
   registerComponents?: boolean
   useHead?: boolean
+  rootContainer?: string | Element
 }
 
 export type RouterOptions = PartialKeys<VueRouterOptions, 'history'> & { base?: string }


### PR DESCRIPTION
adds `rootContainer` option, defaulting to "#app", to let users specify where to mount the app.

fixes #38 