### PR TITLE
fix: children with leading / at root level

### DIFF
--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -13,7 +13,7 @@ export function routesToPaths(routes?: RouteRecordRaw[]) {
   if (!routes)
     return ['/']
 
-  const paths: string[] = []
+  const paths: Set<string> = new Set()
 
   const getPaths = (routes: RouteRecordRaw[], prefix = '') => {
     // remove trailing slash
@@ -21,7 +21,7 @@ export function routesToPaths(routes?: RouteRecordRaw[]) {
     for (const route of routes) {
       // check for leading slash
       if (route.path) {
-        paths.push(
+        paths.add(
           prefix && !route.path.startsWith('/')
             ? `${prefix}/${route.path}`
             : route.path,
@@ -33,6 +33,5 @@ export function routesToPaths(routes?: RouteRecordRaw[]) {
   }
 
   getPaths(routes)
-
-  return paths
+  return [...paths]
 }

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -16,10 +16,10 @@ export function routesToPaths(routes?: RouteRecordRaw[]) {
   const paths: string[] = []
 
   const getPaths = (routes: RouteRecordRaw[], prefix = '') => {
-    // remove tailing slash
+    // remove trailing slash
     prefix = prefix.replace(/\/$/g, '')
     for (const route of routes) {
-      // remove leading slash
+      // check for leading slash
       if (route.path) {
         paths.push(
           prefix && !route.path.startsWith('/')

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -22,8 +22,8 @@ export function routesToPaths(routes?: RouteRecordRaw[]) {
       // remove leading slash
       if (route.path) {
         paths.push(
-          prefix
-            ? `${prefix}/${route.path.replace(/^\//g, '')}`
+          prefix && !route.path.startsWith('/')
+            ? `${prefix}/${route.path}`
             : route.path,
         )
       }


### PR DESCRIPTION
fixes #44

## Motivation
Currently, a route with `prefix` will always strip the leading `/` and append the route to the prefix. After the change, only a route without a leading `/` would be concatenated with `prefix`. If the route has a leading `/` (prefix or not) the path will be taken verbatim.