### PR TITLE
fix: using localStorage(sessionStorage) and timer function in vue sfc will block building

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -88,7 +88,8 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
   buildLog('Rendering Pages...', routesPaths.length)
 
   if (mock) {
-    const jsdom = new JSDOM('', { url: 'http://localhost' })
+    const virtualConsole = new JSDOM.VirtualConsole();
+    const jsdom = new JSDOM('', { url: 'http://localhost', virtualConsole })
     // @ts-ignore
     global.window = jsdom.window
     Object.assign(global, jsdom.window)

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -88,7 +88,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
   buildLog('Rendering Pages...', routesPaths.length)
 
   if (mock) {
-    const jsdom = new JSDOM()
+    const jsdom = new JSDOM('', { url: 'http://localhost' })
     // @ts-ignore
     global.window = jsdom.window
     Object.assign(global, jsdom.window)


### PR DESCRIPTION
`url options` is required in jsdom constructor when using `localStorage` or `sessionStorage`.
Otherwise building will fail by `[DOMException [SecurityError]: localStorage is not available for opaque origins]`

[Relative Issue](https://github.com/jsdom/jsdom/issues/2304#issuecomment-408320484)
