### PR TITLE
feat: Extract `initialState` to asset to respect CSP

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,9 +1,9 @@
 import { createSSRApp, Component, createApp as createClientApp } from 'vue'
 import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router'
 import { createHead, HeadClient } from '@vueuse/head'
-import type { RouterOptions, ViteSSGContext, ViteSSGClientOptions } from '../types'
 import { deserializeState, serializeState } from '../utils/state'
 import { ClientOnly } from './components/ClientOnly'
+import type { RouterOptions, ViteSSGContext, ViteSSGClientOptions } from '../types'
 
 export * from '../types'
 


### PR DESCRIPTION
This PR extracts the `initialState` (#42) to an asset file at build time and, thus, avoids an inline script.
For that reason, it now respects the default of CSP where no inline scripts are allowed.

Closes #49.