### PR TITLE
feat: support dirStyle and includeAllRoutes options

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -45,7 +45,8 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
     onBeforePageRender,
     onPageRendered,
     onFinished,
-    useIndexMode = false,
+    dirStyle = 'flat',
+    includeAllRoutes = false,
   }: ViteSSGOptions = Object.assign({}, config.ssgOptions || {}, cliOptions)
 
   if (fs.existsSync(ssgOut))
@@ -88,7 +89,10 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
 
   const { routes, initialState } = await createApp(false)
 
-  let routesPaths = useIndexMode ? routesToPaths(routes) : await includedRoutes(routesToPaths(routes))
+  let routesPaths = includeAllRoutes
+    ? routesToPaths(routes)
+    : await includedRoutes(routesToPaths(routes))
+
   // uniq
   routesPaths = Array.from(new Set(routesPaths))
 
@@ -144,10 +148,12 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
       const formatted = format(transformed, formatting)
 
       const relativeRoute = (route.endsWith('/') ? `${route}index` : route).replace(/^\//g, '')
-      const filename = useIndexMode ? "index.html" : `${relativeRoute}.html`
+      const filename = dirStyle === 'nested'
+        ? join(relativeRoute, 'index.html')
+        : `${relativeRoute}.html`
 
-      await fs.ensureDir(join(out, useIndexMode ? route :  dirname(relativeRoute)))
-      await fs.writeFile(join(out + (useIndexMode ? route : ""), filename), formatted, 'utf-8')
+      await fs.ensureDir(join(out, dirname(filename)))
+      await fs.writeFile(join(out, filename), formatted, 'utf-8')
 
       config.logger.info(
         `${chalk.dim(`${outDir}/`)}${chalk.cyan(filename.padEnd(15, ' '))}  ${chalk.dim(getSize(formatted))}`,

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -45,6 +45,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
     onBeforePageRender,
     onPageRendered,
     onFinished,
+    useIndexMode = false,
   }: ViteSSGOptions = Object.assign({}, config.ssgOptions || {}, cliOptions)
 
   if (fs.existsSync(ssgOut))
@@ -87,7 +88,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
 
   const { routes, initialState } = await createApp(false)
 
-  let routesPaths = await includedRoutes(routesToPaths(routes))
+  let routesPaths = useIndexMode ? routesToPaths(routes) : await includedRoutes(routesToPaths(routes))
   // uniq
   routesPaths = Array.from(new Set(routesPaths))
 
@@ -143,10 +144,10 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
       const formatted = format(transformed, formatting)
 
       const relativeRoute = (route.endsWith('/') ? `${route}index` : route).replace(/^\//g, '')
-      const filename = `${relativeRoute}.html`
+      const filename = useIndexMode ? "index.html" : `${relativeRoute}.html`
 
-      await fs.ensureDir(join(out, dirname(relativeRoute)))
-      await fs.writeFile(join(out, filename), formatted, 'utf-8')
+      await fs.ensureDir(join(out, useIndexMode ? route :  dirname(relativeRoute)))
+      await fs.writeFile(join(out + (useIndexMode ? route : ""), filename), formatted, 'utf-8')
 
       config.logger.info(
         `${chalk.dim(`${outDir}/`)}${chalk.cyan(filename.padEnd(15, ' '))}  ${chalk.dim(getSize(formatted))}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,47 @@ export interface ViteSSGOptions {
    */
   onPageRendered?: (route: string, renderedHTML: string) => Promise<string | null | undefined> | string | null | undefined
 
-  onFinished?: () => void
+  onFinished?: () => void,
+
+
+  /**
+   * vue-route use index.html to build files
+   * 
+   * e.g  routes =   [
+   *      {
+   *         name: 'index',
+   *         path: '/',
+   *         component: [Function: component],
+   *         props: true
+   *      },
+   *      {
+   *         name: 'list-card',
+   *         path: '/list/card',
+   *         component: [Function: component],
+   *         props: true
+   *      },
+   *      {
+   *         name: 'user',
+   *         path: '/user',
+   *         component: [Function: component],
+   *         props: true
+   *      },
+   *      {
+   *         name: 'user-id',
+   *         path: '/user/:id',
+   *         component: [Function: component],
+   *         props: true
+   *      }
+   *  ]
+   * 
+   * file paths :  [
+   *     ~dist/index.html,
+   *     ~dist/list/card/index.html,
+   *     ~dist/user/index.html
+   *     ~dist/user/:id/index.html
+   * ]
+   */
+  useIndexMode?: boolean
 }
 
 type PartialKeys<T, Keys extends keyof T> = Omit<T, Keys> & Partial<Pick<T, Keys>>

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,9 +33,28 @@ export interface ViteSSGOptions {
   formatting?: 'minify' | 'prettify' | 'none'
 
   /**
-   * Vite enviroument mode
+   * Vite environment mode
    */
   mode?: string
+
+  /**
+   * Directory style of the output directory.
+   *
+   * flat: `/foo` -> `/foo.html`
+   * nested: `/foo` -> `/foo/index.html`
+   *
+   * @default flat
+   */
+  dirStyle?: 'flat' | 'nested'
+
+  /**
+    * Generate for all routes, including dynamic routes.
+    * If enabled, you will need to configure your server
+    * manually to handle dynamic routes properly.
+    *
+    * @default false
+    */
+  includeAllRoutes?: boolean
 
   /**
    * Options for critters
@@ -46,6 +65,8 @@ export interface ViteSSGOptions {
 
   /**
    * Custom functions to modified the routes to do the SSG.
+   *
+   * Works only when `includeAllRoutes` is set to false.
    *
    * Default to a handler that filter out all the dynamic routes,
    * when passing your custom handler, you should also take care the dynamic routes yourself.
@@ -66,47 +87,7 @@ export interface ViteSSGOptions {
    */
   onPageRendered?: (route: string, renderedHTML: string) => Promise<string | null | undefined> | string | null | undefined
 
-  onFinished?: () => void,
-
-
-  /**
-   * vue-route use index.html to build files
-   * 
-   * e.g  routes =   [
-   *      {
-   *         name: 'index',
-   *         path: '/',
-   *         component: [Function: component],
-   *         props: true
-   *      },
-   *      {
-   *         name: 'list-card',
-   *         path: '/list/card',
-   *         component: [Function: component],
-   *         props: true
-   *      },
-   *      {
-   *         name: 'user',
-   *         path: '/user',
-   *         component: [Function: component],
-   *         props: true
-   *      },
-   *      {
-   *         name: 'user-id',
-   *         path: '/user/:id',
-   *         component: [Function: component],
-   *         props: true
-   *      }
-   *  ]
-   * 
-   * file paths :  [
-   *     ~dist/index.html,
-   *     ~dist/list/card/index.html,
-   *     ~dist/user/index.html
-   *     ~dist/user/:id/index.html
-   * ]
-   */
-  useIndexMode?: boolean
+  onFinished?: () => void
 }
 
 type PartialKeys<T, Keys extends keyof T> = Omit<T, Keys> & Partial<Pick<T, Keys>>


### PR DESCRIPTION
# File System Routing
When you use nginx to deploy a static website, nginx will look for the index.html file under $URI, so add the useindexmode option to generate the corresponding path
Recommended for use with [vite-plugin-pages](https://github.com/hannoeru/vite-plugin-pages)

for example:
```
routes =   [
      {
         name: 'index',
         path: '/',
         component: [Function: component],
         props: true
      },
      {
         name: 'list-card',
         path: '/list/card',
         component: [Function: component],
         props: true
      },
      {
         name: 'user',
         path: '/user',
         component: [Function: component],
         props: true
      },
      {
         name: 'user-id',
         path: '/user/:id',
         component: [Function: component],
         props: true
      }
]
```

build after :
```
    ...
     ~dist/index.html,
     ~dist/list/card/index.html,
     ~dist/user/index.html
     ~dist/user/:id/index.html
```


# Dynamic Route Matching
With nginx vhost, dynamic routing of static pages can be realized

for example https://www.xxxx.com/user/123:
```
location ~* /user/[0-9]+$ {
    try_files $uri /user/:id/index.html;
}
```

for example https://www.xxxx.com/user/456/details:
```
location ~* /user/[0-9]+/details {
    try_files $uri /user/:id/details/index.html;
}
```