### PR TITLE
fix: install router after user setup

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -42,8 +42,6 @@ export function ViteSSG(
 
     const { routes } = routerOptions
 
-    app.use(router)
-
     if (registerComponents)
       app.component('ClientOnly', client ? ClientOnly : { render: () => null })
 
@@ -62,6 +60,8 @@ export function ViteSSG(
       context.initialState = transformState?.(window.__INITIAL_STATE__ || {}) || deserializeState(window.__INITIAL_STATE__)
 
     await fn?.(context)
+
+    app.use(router)
 
     let entryRoutePath: string | undefined
     let isFirstRoute = true


### PR DESCRIPTION
When adding router guards in modules (that are loaded in the fn argument) I expected that when entering a page (not by navigation but by typing in the url) the route would execute the guard, but it does not.

To remedy the guards should be set on the router before registering with vue.