### PR TITLE
feat: pass context to user application, close #124

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -121,14 +121,15 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
   await Promise.all(
     routesPaths.map(async(route) => {
       try {
-        const { app, router, head, initialState } = await createApp(false, route)
+        const appCtx = await createApp(false, route)
+        const { app, router, head, initialState } = appCtx
 
         if (router) {
           await router.push(route)
           await router.isReady()
         }
 
-        const transformedIndexHTML = (await onBeforePageRender?.(route, indexHTML)) || indexHTML
+        const transformedIndexHTML = (await onBeforePageRender?.(route, indexHTML, appCtx as ViteSSGContext<true>)) || indexHTML
 
         const ctx: SSRContext = {}
         const appHTML = await renderToString(app, ctx)
@@ -146,7 +147,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
         head?.updateDOM(jsdom.window.document)
 
         const html = jsdom.serialize()
-        let transformed = (await onPageRendered?.(route, html)) || html
+        let transformed = (await onPageRendered?.(route, html, appCtx)) || html
         if (critters)
           transformed = await critters.process(transformed)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,14 +78,14 @@ export interface ViteSSGOptions {
    *
    * Also give the change to transform the index html passed to the renderer.
    */
-  onBeforePageRender?: (route: string, indexHTML: string) => Promise<string | null | undefined> | string | null | undefined
+  onBeforePageRender?: (route: string, indexHTML: string, appCtx: ViteSSGContext<true>) => Promise<string | null | undefined> | string | null | undefined
 
   /**
    * Callback to be called on every page rendered.
    *
    * Also give the change to transform the rendered html by returning a string.
    */
-  onPageRendered?: (route: string, renderedHTML: string) => Promise<string | null | undefined> | string | null | undefined
+  onPageRendered?: (route: string, renderedHTML: string, appCtx: ViteSSGContext<true>) => Promise<string | null | undefined> | string | null | undefined
 
   onFinished?: () => Promise<void> | void
 }


### PR DESCRIPTION
This is required to successfully prerender apps using the [NaiveUI](https://www.naiveui.com/) component library.

I will provide an example config here soon.

Closes #124