### PR TITLE
fix: nested routes when parent path is empty

### DIFF
--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -21,10 +21,11 @@ export function routesToPaths(routes?: RouteRecordRaw[]) {
     prefix = prefix.replace(/\/$/g, '')
     for (const route of routes) {
       let path = route.path
+
       // check for leading slash
-      if (route.path) {
+      if (route.path != null) {
         path = prefix && !route.path.startsWith('/')
-          ? `${prefix}/${route.path}`
+          ? `${prefix}${route.path ? `/${route.path}` : ''}`
           : route.path
 
         paths.add(path)
@@ -35,5 +36,5 @@ export function routesToPaths(routes?: RouteRecordRaw[]) {
   }
 
   getPaths(routes)
-  return [...paths]
+  return Array.from(paths)
 }


### PR DESCRIPTION
There was a previous attempt to fix this (https://github.com/antfu/vite-ssg/pull/91) but there are remaining broken cases. When routes have an empty path, their children are not processed, causing nested routes to be missed and remain unprefixed.

```javascript
//Previous implementation
console.log(routesToPaths([
  {
    path: '/foo',
    children: [{path: '', children: [{ path: 'bar' }, {path: '/bar'}] }]
  }
]))

//outputs [ '/foo', 'bar', '/bar' ] - incorrect

//With this PR

console.log(routesToPaths([
  {
    path: '/foo',
    children: [{path: '', children: [{ path: 'bar' }, {path: '/bar'}] }]
  }
]))

//outputs [ '/foo', '/foo/bar', '/bar' ]
```