### PR TITLE
feat: pass original routes to includedRoutes cb

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,9 +297,26 @@ You can use the `includedRoutes` hook to exclude/include route paths to render, 
 export default {
   plugins: [ /*...*/ ],
   ssgOptions: {
-    includedRoutes(routes) {
+    includedRoutes(paths) {
       // exclude all the route paths that contains 'foo'
-      return routes.filter(i => !i.includes('foo'))
+      return paths.filter(i => !i.includes('foo'))
+    }
+  }
+}
+```
+```js
+// vite.config.js
+
+export default {
+  plugins: [ /*...*/ ],
+  ssgOptions: {
+    includedRoutes(paths, routes) {
+      // use original route records
+      return routes.flatMap(route => {
+        return route.name === 'Blog'
+          ? myBlogSlugs.map(slug => `/blog/${slug}`)
+          : route.path
+      })
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ You can use the `includedRoutes` hook to exclude/include route paths to render, 
 export default {
   plugins: [ /*...*/ ],
   ssgOptions: {
-    includedRoutes(paths) {
+    includedRoutes(paths, routes) {
       // exclude all the route paths that contains 'foo'
       return paths.filter(i => !i.includes('foo'))
     }

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -11,6 +11,7 @@ import { ViteSSGContext, ViteSSGOptions } from '../client'
 import { renderPreloadLinks } from './preload-links'
 import { buildLog, routesToPaths, getSize } from './utils'
 import { getCritters } from './critical'
+import { RouteRecordRaw } from 'vue-router'
 
 export interface Manifest {
   [key: string]: string[]
@@ -18,7 +19,7 @@ export interface Manifest {
 
 export type CreateAppFactory = (client: boolean, routePath?: string) => Promise<ViteSSGContext<true> | ViteSSGContext<false>>
 
-function DefaultIncludedRoutes(paths: string[]) {
+function DefaultIncludedRoutes(paths: string[], routes: RouteRecordRaw[]) {
   // ignore dynamic routes
   return paths.filter(i => !i.includes(':') && !i.includes('*'))
 }
@@ -95,7 +96,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
 
   let routesPaths = includeAllRoutes
     ? routesToPaths(routes)
-    : await includedRoutes(routesToPaths(routes))
+    : await includedRoutes(routesToPaths(routes), routes || [])
 
   // uniq
   routesPaths = Array.from(new Set(routesPaths))

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,7 @@ export interface ViteSSGOptions {
    * Default to a handler that filter out all the dynamic routes,
    * when passing your custom handler, you should also take care the dynamic routes yourself.
    */
-  includedRoutes?: (routes: string[]) => Promise<string[]> | string[]
+  includedRoutes?: (paths: string[], routes: RouteRecordRaw[]) => Promise<string[]> | string[]
 
   /**
    * Callback to be called before every page render.


### PR DESCRIPTION
Suggestion to pass original route records to `includedRoutes` to allow for construction of dynamic paths without having to parse path strings.