### PR TITLE
Add unit testing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/*/README.md
 .vite-ssg-temp
 *.d.ts
 .idea/
+dist-test

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    "typescript": {
+        "rewritePaths": {
+            "src/": "dist/",
+            "test/": "dist-test/"
+        },
+        "compile": false
+    },
+    "files": ["test/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -55,9 +55,10 @@
     "example:single:dev": "npm -C examples/single-page run dev",
     "example:single:build": "npm -C examples/single-page run build",
     "example:single:serve": "npm -C examples/single-page run serve",
-    "build": "tsup && npm run copy-single-page-dts",
+    "build": "tsup && npm run copy-single-page-dts && tsup test/main.ts -d dist-test",
     "prepublishOnly": "npm run build",
-    "release": "npx bumpp --push --tag --commit"
+    "release": "npx bumpp --push --tag --commit",
+    "test": "ava"
   },
   "dependencies": {
     "chalk": "^4.1.2",
@@ -81,11 +82,13 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.10.0",
+    "@ava/typescript": "^3.0.1",
     "@types/fs-extra": "^9.0.13",
     "@types/jsdom": "^16.2.13",
     "@types/yargs": "^17.0.5",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@vueuse/head": "^0.6.0",
+    "ava": "^4.0.0-rc.1",
     "bumpp": "^7.1.1",
     "critters": "^0.0.14",
     "eslint": "^8.2.0",

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,0 +1,11 @@
+import test from 'ava';
+import { RouteRecordRaw } from 'vue-router';
+import { routesToPaths } from '../src/node/utils.js';
+
+test('Routes parsed to paths', t => {
+    t.deepEqual(
+        routesToPaths([
+            {'path': 'foo'} as RouteRecordRaw
+        ]), ['foo']
+    );
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,10 @@
     "strictNullChecks": true,
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
   },
   "exclude": [
     "**/dist",
-    "**/node_modules",
-    "**/test"
+    "**/node_modules"
   ]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,6 +5,7 @@ export default <Options>{
     'src/index.ts',
     'src/client/single-page.ts',
     'src/node/cli.ts',
+    'src/node/utils.ts'
   ],
   dts: true,
   splitting: true,
@@ -16,6 +17,7 @@ export default <Options>{
     'vue',
     'vue/server-renderer',
     'vue/compiler-sfc',
+    'ava'
   ],
   clean: true,
 }


### PR DESCRIPTION
Addresses https://github.com/antfu/vite-ssg/issues/136

- Installs ava as testing framework
- Necessary ts config and tsup config changes to get tests running
- Basic unit test of `routesToPaths` function

One caveat of the way this is setup - tests require / assume that the `build` script has been run.

TODO

- [x] Initial setup
- [ ] CI setup
- [ ] Coverage setup
- [ ] Decide on required coverage threshold
- [ ] Get coverage to required threshold

We should discuss testability of the different units of this package. The only function I have really looked at yet is `routesToPaths`, which is quite easily testable. Other parts may be more difficult to test, and possibly require breaking them down into smaller units.