### PR TITLE
feat: move to unbuild

### DIFF
--- a/bin/vite-ssg.js
+++ b/bin/vite-ssg.js
@@ -1,3 +1,6 @@
 #!/usr/bin/env node
 'use strict'
-import('../dist/node/cli.mjs')
+if (typeof __dirname !== 'undefined')
+  require('../dist/node/cli.cjs')
+else
+  import('../dist/node/cli.mjs')

--- a/build.config.ts
+++ b/build.config.ts
@@ -1,0 +1,19 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  entries: [
+    { input: 'src/index', name: 'index' },
+    { input: 'src/client/single-page', name: 'client/single-page' },
+    { input: 'src/node/cli', name: 'node/cli' },
+  ],
+  clean: true,
+  declaration: true,
+  externals: [
+    'vue',
+    'vue/server-renderer',
+    'vue/compiler-sfc',
+  ],
+  rollup: {
+    emitCJS: true,
+  },
+})

--- a/examples/multiple-pages-pwa/package.json
+++ b/examples/multiple-pages-pwa/package.json
@@ -6,17 +6,17 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.2.22"
+    "vue": "^3.2.26"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^1.9.4",
+    "@vitejs/plugin-vue": "^2.0.1",
     "cross-env": "^7.0.3",
-    "typescript": "^4.4.4",
-    "vite": "^2.6.14",
+    "typescript": "^4.5.4",
+    "vite": "^2.7.10",
     "vite-plugin-components": "^0.13.3",
-    "vite-plugin-md": "^0.11.4",
-    "vite-plugin-pages": "^0.18.2",
-    "vite-plugin-pwa": "^0.11.5",
+    "vite-plugin-md": "^0.11.7",
+    "vite-plugin-pages": "^0.19.8",
+    "vite-plugin-pwa": "^0.11.12",
     "vite-ssg": "workspace:*",
     "vue-router": "^4.0.12"
   }

--- a/examples/multiple-pages-with-store/package.json
+++ b/examples/multiple-pages-with-store/package.json
@@ -6,18 +6,18 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "pinia": "2.0.3",
-    "vue": "^3.2.22"
+    "pinia": "2.0.9",
+    "vue": "^3.2.26"
   },
   "devDependencies": {
     "@nuxt/devalue": "^2.0.0",
-    "@vitejs/plugin-vue": "^1.9.4",
+    "@vitejs/plugin-vue": "^2.0.1",
     "cross-env": "^7.0.3",
-    "typescript": "^4.4.4",
-    "vite": "^2.6.14",
+    "typescript": "^4.5.4",
+    "vite": "^2.7.10",
     "vite-plugin-components": "^0.13.3",
-    "vite-plugin-md": "^0.11.4",
-    "vite-plugin-pages": "^0.18.2",
+    "vite-plugin-md": "^0.11.7",
+    "vite-plugin-pages": "^0.19.8",
     "vite-ssg": "workspace:*",
     "vue-router": "^4.0.12"
   }

--- a/examples/multiple-pages/package.json
+++ b/examples/multiple-pages/package.json
@@ -6,16 +6,16 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.2.22"
+    "vue": "^3.2.26"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^1.9.4",
+    "@vitejs/plugin-vue": "^2.0.1",
     "cross-env": "^7.0.3",
-    "typescript": "^4.4.4",
-    "vite": "^2.6.14",
+    "typescript": "^4.5.4",
+    "vite": "^2.7.10",
     "vite-plugin-components": "^0.13.3",
-    "vite-plugin-md": "^0.11.4",
-    "vite-plugin-pages": "^0.18.2",
+    "vite-plugin-md": "^0.11.7",
+    "vite-plugin-pages": "^0.19.8",
     "vite-ssg": "workspace:*",
     "vue-router": "^4.0.12"
   }

--- a/examples/single-page/package.json
+++ b/examples/single-page/package.json
@@ -6,14 +6,14 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "pinia": "^2.0.3",
-    "vue": "^3.2.22"
+    "pinia": "^2.0.9",
+    "vue": "^3.2.26"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^1.9.4",
+    "@vitejs/plugin-vue": "^2.0.1",
     "cross-env": "^7.0.3",
-    "typescript": "^4.4.4",
-    "vite": "^2.6.14",
+    "typescript": "^4.5.4",
+    "vite": "^2.7.10",
     "vite-ssg": "workspace:*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,12 +61,12 @@
     "release": "npx bumpp --push --tag --commit"
   },
   "dependencies": {
-    "chalk": "^4.1.2",
+    "chalk": "^5.0.0",
     "fs-extra": "^10.0.0",
     "html-minifier": "^4.0.0",
     "jsdom": "^19.0.0",
     "prettier": "^2.5.1",
-    "yargs": "^17.3.0"
+    "yargs": "^17.3.1"
   },
   "peerDependencies": {
     "@vueuse/head": "^0.5.1",
@@ -81,23 +81,23 @@
     }
   },
   "devDependencies": {
-    "@antfu/eslint-config": "^0.14.0",
+    "@antfu/eslint-config": "^0.14.2",
     "@types/fs-extra": "^9.0.13",
-    "@types/html-minifier": "^4.0.1",
-    "@types/jsdom": "^16.2.13",
+    "@types/html-minifier": "^4.0.2",
+    "@types/jsdom": "^16.2.14",
     "@types/prettier": "^2.4.2",
-    "@types/yargs": "^17.0.7",
-    "@typescript-eslint/eslint-plugin": "^5.7.0",
+    "@types/yargs": "^17.0.8",
+    "@typescript-eslint/eslint-plugin": "^5.8.1",
     "@vueuse/head": "^0.7.4",
     "bumpp": "^7.1.1",
     "critters": "^0.0.15",
     "eslint": "^8.5.0",
     "esno": "^0.13.0",
-    "rollup": "^2.61.1",
+    "rollup": "^2.62.0",
     "standard-version": "^9.3.2",
-    "tsup": "^5.11.6",
+    "tsup": "^5.11.9",
     "typescript": "^4.5.4",
-    "vite": "^2.7.3",
+    "vite": "^2.7.10",
     "vite-plugin-pwa": "^0.11.12",
     "vue": "^3.2.26",
     "vue-router": "^4.0.12"

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     "release": "npx bumpp --push --tag --commit"
   },
   "dependencies": {
-    "chalk": "^5.0.0",
     "fs-extra": "^10.0.0",
     "html-minifier": "^4.0.0",
     "jsdom": "^19.0.0",
+    "kolorist": "^1.5.1",
     "prettier": "^2.5.1",
     "yargs": "^17.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
   "name": "vite-ssg",
-  "description": "Server-side generation for Vite",
   "version": "0.17.2",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
-  "exports": {
-    "./": "./",
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
-    },
-    "./single-page": {
-      "require": "./dist/client/single-page.js",
-      "import": "./dist/client/single-page.mjs"
-    }
-  },
-  "license": "MIT",
-  "funding": "https://github.com/sponsors/antfu",
-  "author": "Anthony Fu <anthonyfu117@hotmail.com>",
-  "engines": {
-    "node": ">=14.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/antfu/vite-ssg"
-  },
-  "homepage": "https://github.com/antfu/vite-ssg",
-  "bugs": "https://github.com/antfu/vite-ssg/issues",
-  "files": [
-    "dist",
-    "bin",
-    "single-page.d.ts"
-  ],
-  "bin": {
-    "vite-ssg": "bin/vite-ssg.js"
-  },
+  "description": "Server-side generation for Vite",
   "keywords": [
     "vite",
     "vite-plugin",
     "ssg",
     "ssr"
   ],
+  "homepage": "https://github.com/antfu/vite-ssg",
+  "bugs": "https://github.com/antfu/vite-ssg/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antfu/vite-ssg"
+  },
+  "funding": "https://github.com/sponsors/antfu",
+  "license": "MIT",
+  "author": "Anthony Fu <anthonyfu117@hotmail.com>",
+  "sideEffects": false,
+  "exports": {
+    "./": "./",
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./single-page": {
+      "require": "./dist/client/single-page.cjs",
+      "import": "./dist/client/single-page.mjs",
+      "types": "./dist/client/single-page.d.ts"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "bin",
+    "*.d.ts"
+  ],
+  "bin": {
+    "vite-ssg": "bin/vite-ssg.js"
+  },
   "scripts": {
     "dev": "tsup --watch src",
     "lint": "eslint --ext .ts,.js .",
@@ -56,7 +56,7 @@
     "example:single:dev": "npm -C examples/single-page run dev",
     "example:single:build": "npm -C examples/single-page run build",
     "example:single:serve": "npm -C examples/single-page run serve",
-    "build": "tsup && npm run copy-single-page-dts",
+    "build": "unbuild && npm run copy-single-page-dts",
     "prepublishOnly": "npm run build",
     "release": "npx bumpp --push --tag --commit"
   },
@@ -97,9 +97,13 @@
     "standard-version": "^9.3.2",
     "tsup": "^5.11.9",
     "typescript": "^4.5.4",
+    "unbuild": "^0.6.7",
     "vite": "^2.7.10",
     "vite-plugin-pwa": "^0.11.12",
     "vue": "^3.2.26",
     "vue-router": "^4.0.12"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ importers:
       standard-version: ^9.3.2
       tsup: ^5.11.9
       typescript: ^4.5.4
+      unbuild: ^0.6.7
       vite: ^2.7.10
       vite-plugin-pwa: ^0.11.12
       vue: ^3.2.26
@@ -54,6 +55,7 @@ importers:
       standard-version: 9.3.2
       tsup: 5.11.9_typescript@4.5.4
       typescript: 4.5.4
+      unbuild: 0.6.7
       vite: 2.7.10
       vite-plugin-pwa: 0.11.12_vite@2.7.10
       vue: 3.2.26
@@ -274,6 +276,15 @@ packages:
     dependencies:
       '@babel/highlight': 7.14.5
     dev: true
+
+  /@babel/code-frame/7.16.0:
+    resolution: {integrity: sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==}
+    engines: {node: '>=6.9.0'}
+    requiresBuild: true
+    dependencies:
+      '@babel/highlight': 7.16.0
+    dev: true
+    optional: true
 
   /@babel/compat-data/7.14.7:
     resolution: {integrity: sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==}
@@ -521,6 +532,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-validator-identifier/7.15.7:
+    resolution: {integrity: sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+    optional: true
+
   /@babel/helper-validator-option/7.14.5:
     resolution: {integrity: sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==}
     engines: {node: '>=6.9.0'}
@@ -557,6 +574,16 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
+
+  /@babel/highlight/7.16.0:
+    resolution: {integrity: sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.15.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+    optional: true
 
   /@babel/parser/7.15.3:
     resolution: {integrity: sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==}
@@ -1456,6 +1483,16 @@ packages:
     resolution: {integrity: sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==}
     dev: true
 
+  /@rollup/plugin-alias/3.1.8_rollup@2.62.0:
+    resolution: {integrity: sha512-tf7HeSs/06wO2LPqKNY3Ckbvy0JRe7Jyn98bXnt/gfrxbe+AJucoNJlsEVi9sdgbQtXemjbakCpO/76JVgnHpA==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      rollup: 2.62.0
+      slash: 3.0.0
+    dev: true
+
   /@rollup/plugin-babel/5.3.0_@babel+core@7.14.8+rollup@2.62.0:
     resolution: {integrity: sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==}
     engines: {node: '>= 10.0.0'}
@@ -1469,6 +1506,31 @@ packages:
     dependencies:
       '@babel/core': 7.14.8
       '@babel/helper-module-imports': 7.14.5
+      '@rollup/pluginutils': 3.1.0_rollup@2.62.0
+      rollup: 2.62.0
+    dev: true
+
+  /@rollup/plugin-commonjs/21.0.1_rollup@2.62.0:
+    resolution: {integrity: sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^2.38.3
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.62.0
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 7.1.7
+      is-reference: 1.2.1
+      magic-string: 0.25.7
+      resolve: 1.20.0
+      rollup: 2.62.0
+    dev: true
+
+  /@rollup/plugin-json/4.1.0_rollup@2.62.0:
+    resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.62.0
       rollup: 2.62.0
     dev: true
@@ -1488,8 +1550,33 @@ packages:
       rollup: 2.62.0
     dev: true
 
+  /@rollup/plugin-node-resolve/13.1.1_rollup@2.62.0:
+    resolution: {integrity: sha512-6QKtRevXLrmEig9UiMYt2fSvee9TyltGRfw+qSs6xjUnxwjOzTOqy+/Lpxsgjb8mJn1EQNbCDAvt89O4uzL5kw==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      rollup: ^2.42.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.62.0
+      '@types/resolve': 1.17.1
+      builtin-modules: 3.2.0
+      deepmerge: 4.2.2
+      is-module: 1.0.0
+      resolve: 1.20.0
+      rollup: 2.62.0
+    dev: true
+
   /@rollup/plugin-replace/2.4.2_rollup@2.62.0:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.62.0
+      magic-string: 0.25.7
+      rollup: 2.62.0
+    dev: true
+
+  /@rollup/plugin-replace/3.0.1_rollup@2.62.0:
+    resolution: {integrity: sha512-989J5oRzf3mm0pO/0djTijdfEh9U3n63BIXN5X7T4U9BP+fN4oxQ6DvDuBvFaHA6scaHQRclqmKQEkBhB7k7Hg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
@@ -2274,6 +2361,11 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /chalk/5.0.0:
+    resolution: {integrity: sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
   /chokidar/3.5.1:
     resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
     engines: {node: '>= 8.10.0'}
@@ -2367,6 +2459,10 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: true
 
+  /commondir/1.0.1:
+    resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
+    dev: true
+
   /compare-func/2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
     dependencies:
@@ -2386,6 +2482,10 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.0
       typedarray: 0.0.6
+    dev: true
+
+  /consola/2.15.3:
+    resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
     dev: true
 
   /conventional-changelog-angular/5.0.12:
@@ -2762,6 +2862,10 @@ packages:
       object-keys: 1.1.1
     dev: true
 
+  /defu/5.0.0:
+    resolution: {integrity: sha512-VHg73EDeRXlu7oYWRmmrNp/nl7QkdXUxkQQKig0Zk8daNmm84AbGoC8Be6/VVLJEKxn12hR0UBmz8O+xQiAPKQ==}
+    dev: true
+
   /delayed-stream/1.0.0:
     resolution: {integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=}
     engines: {node: '>=0.4.0'}
@@ -2925,6 +3029,10 @@ packages:
       is-set: 2.0.2
       is-string: 1.0.7
       isarray: 2.0.5
+    dev: true
+
+  /es-module-lexer/0.9.3:
+    resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
     dev: true
 
   /es-to-primitive/1.2.1:
@@ -3841,7 +3949,6 @@ packages:
       graceful-fs: 4.2.6
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: false
 
   /fs-extra/9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -4086,6 +4193,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: false
+
+  /hookable/5.1.1:
+    resolution: {integrity: sha512-7qam9XBFb+DijNBthaL1k/7lHU2TEMZkWSyuqmU3sCQze1wFm5w9AlEx30PD7a+QVAjOy6Ec2goFwe1YVyk2uA==}
+    dev: true
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -4369,6 +4480,12 @@ packages:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
     dev: false
 
+  /is-reference/1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    dependencies:
+      '@types/estree': 0.0.39
+    dev: true
+
   /is-regex/1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -4474,6 +4591,11 @@ packages:
       '@types/node': 16.4.8
       merge-stream: 2.0.0
       supports-color: 7.2.0
+    dev: true
+
+  /jiti/1.12.9:
+    resolution: {integrity: sha512-TdcJywkQtcwLxogc4rSMAi479G2eDPzfW0fLySks7TPhgZZ4s/tM6stnzayIh3gS/db3zExWJyUx4cNWrwAmoQ==}
+    hasBin: true
     dev: true
 
   /joycon/3.0.1:
@@ -4912,15 +5034,49 @@ packages:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
     dev: true
 
+  /mkdirp/1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
+  /mkdist/0.3.8_typescript@4.5.4:
+    resolution: {integrity: sha512-XPfx3KkJPpxPE17csksGoJkTerOcVIoBpJQATiwn5kZ3pwb9wPmeAoAbShm0WwPfzGvv4k8pZyA9/SFf+BF+Jg==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=3.7'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      defu: 5.0.0
+      esbuild: 0.13.14
+      fs-extra: 10.0.0
+      globby: 11.0.4
+      jiti: 1.12.9
+      mri: 1.2.0
+      pathe: 0.2.0
+      typescript: 4.5.4
+    dev: true
+
   /mlly/0.2.10:
     resolution: {integrity: sha512-xfyW6c2QBGArtctzNnTV5leOKX8nOMz2simeubtXofdsdSJFSNw+Ncvrs8kxcN3pBrQLXuYBHNFV6NgZ5Ryf4A==}
     dependencies:
       import-meta-resolve: 1.1.1
     dev: true
 
+  /mlly/0.3.16:
+    resolution: {integrity: sha512-DVydmuR8fmiMetH39kp8VXYslN0XDh+OxULuU/ov8TMwVIxDGQ8PsJIrNi6cZZaHiIYL6wtO6+sjGpVc7msKUg==}
+    dev: true
+
   /modify-values/1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /mri/1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
     dev: true
 
   /ms/2.0.0:
@@ -5291,6 +5447,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pathe/0.2.0:
+    resolution: {integrity: sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==}
+    dev: true
+
   /picocolors/0.2.1:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
 
@@ -5355,6 +5515,14 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       find-up: 2.1.0
+    dev: true
+
+  /pkg-types/0.3.2:
+    resolution: {integrity: sha512-eBYzX/7NYsQEOR2alWY4rnQB49G62oHzFpoi9Som56aUr8vB8UGcmcIia9v8fpBeuhH3Ltentuk2OGpp4IQV3Q==}
+    dependencies:
+      jsonc-parser: 3.0.0
+      mlly: 0.3.16
+      pathe: 0.2.0
     dev: true
 
   /pluralize/8.0.0:
@@ -5688,6 +5856,38 @@ packages:
       glob: 7.1.7
     dev: true
 
+  /rollup-plugin-dts/4.1.0_rollup@2.62.0+typescript@4.5.4:
+    resolution: {integrity: sha512-rriXIm3jdUiYeiAAd1Fv+x2AxK6Kq6IybB2Z/IdoAW95fb4uRUurYsEYKa8L1seedezDeJhy8cfo8FEL9aZzqg==}
+    engines: {node: '>=v12.22.7'}
+    peerDependencies:
+      rollup: ^2.55
+      typescript: ~4.1 || ~4.2 || ~4.3 || ~4.4 || ~4.5
+    dependencies:
+      magic-string: 0.25.7
+      rollup: 2.62.0
+      typescript: 4.5.4
+    optionalDependencies:
+      '@babel/code-frame': 7.16.0
+    dev: true
+
+  /rollup-plugin-esbuild/4.8.2_esbuild@0.14.5+rollup@2.62.0:
+    resolution: {integrity: sha512-wsaYNOjzTb6dN1qCIZsMZ7Q0LWiPJklYs2TDI8vJA2LUbvtPUY+17TC8C0vSat3jPMInfR9XWKdA7ttuwkjsGQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      esbuild: '>=0.10.1'
+      rollup: ^1.20.0 || ^2.0.0
+    dependencies:
+      '@rollup/pluginutils': 4.1.2
+      debug: 4.3.3
+      es-module-lexer: 0.9.3
+      esbuild: 0.14.5
+      joycon: 3.0.1
+      jsonc-parser: 3.0.0
+      rollup: 2.62.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /rollup-plugin-terser/7.0.2_rollup@2.62.0:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     peerDependencies:
@@ -5746,6 +5946,10 @@ packages:
     dependencies:
       xmlchars: 2.2.0
     dev: false
+
+  /scule/0.2.1:
+    resolution: {integrity: sha512-M9gnWtn3J0W+UhJOHmBxBTwv8mZCan5i1Himp60t6vvZcor0wr+IM0URKmIglsWJ7bRujNAVVN77fp+uZaWoKg==}
+    dev: true
 
   /section-matter/1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -6339,6 +6543,41 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
+  /unbuild/0.6.7:
+    resolution: {integrity: sha512-dbn5mXWASNi+ra9KtxjAY5ifNH5GzrarqU2hexF3pF9J24BrQlH2DC0v1QvhkF1Hw8eS1Pc6HC929Z++TaOuPQ==}
+    hasBin: true
+    dependencies:
+      '@rollup/plugin-alias': 3.1.8_rollup@2.62.0
+      '@rollup/plugin-commonjs': 21.0.1_rollup@2.62.0
+      '@rollup/plugin-json': 4.1.0_rollup@2.62.0
+      '@rollup/plugin-node-resolve': 13.1.1_rollup@2.62.0
+      '@rollup/plugin-replace': 3.0.1_rollup@2.62.0
+      '@rollup/pluginutils': 4.1.2
+      chalk: 5.0.0
+      consola: 2.15.3
+      defu: 5.0.0
+      esbuild: 0.14.5
+      hookable: 5.1.1
+      jiti: 1.12.9
+      magic-string: 0.25.7
+      mkdirp: 1.0.4
+      mkdist: 0.3.8_typescript@4.5.4
+      mlly: 0.3.16
+      mri: 1.2.0
+      pathe: 0.2.0
+      pkg-types: 0.3.2
+      pretty-bytes: 5.6.0
+      rimraf: 3.0.2
+      rollup: 2.62.0
+      rollup-plugin-dts: 4.1.0_rollup@2.62.0+typescript@4.5.4
+      rollup-plugin-esbuild: 4.8.2_esbuild@0.14.5+rollup@2.62.0
+      scule: 0.2.1
+      typescript: 4.5.4
+      untyped: 0.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /unicode-canonical-property-names-ecmascript/1.0.4:
     resolution: {integrity: sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==}
     engines: {node: '>=4'}
@@ -6377,6 +6616,10 @@ packages:
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+
+  /untyped/0.3.0:
+    resolution: {integrity: sha512-n4M5/T1wWlHFmohk0EhS+yM7W/h5dOtQldOV3MVEbZY1fTy5A47UL8+d8GLW1iwmaAwNrM5ERy3qe1k0T/Yc7A==}
+    dev: true
 
   /upath/1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,16 @@ importers:
 
   .:
     specifiers:
-      '@antfu/eslint-config': ^0.14.0
+      '@antfu/eslint-config': ^0.14.2
       '@types/fs-extra': ^9.0.13
-      '@types/html-minifier': ^4.0.1
-      '@types/jsdom': ^16.2.13
+      '@types/html-minifier': ^4.0.2
+      '@types/jsdom': ^16.2.14
       '@types/prettier': ^2.4.2
-      '@types/yargs': ^17.0.7
-      '@typescript-eslint/eslint-plugin': ^5.7.0
+      '@types/yargs': ^17.0.8
+      '@typescript-eslint/eslint-plugin': ^5.8.1
       '@vueuse/head': ^0.7.4
       bumpp: ^7.1.1
-      chalk: ^4.1.2
+      chalk: ^5.0.0
       critters: ^0.0.15
       eslint: ^8.5.0
       esno: ^0.13.0
@@ -21,159 +21,159 @@ importers:
       html-minifier: ^4.0.0
       jsdom: ^19.0.0
       prettier: ^2.5.1
-      rollup: ^2.61.1
+      rollup: ^2.62.0
       standard-version: ^9.3.2
-      tsup: ^5.11.6
+      tsup: ^5.11.9
       typescript: ^4.5.4
-      vite: ^2.7.3
+      vite: ^2.7.10
       vite-plugin-pwa: ^0.11.12
       vue: ^3.2.26
       vue-router: ^4.0.12
-      yargs: ^17.3.0
+      yargs: ^17.3.1
     dependencies:
-      chalk: 4.1.2
+      chalk: 5.0.0
       fs-extra: 10.0.0
       html-minifier: 4.0.0
       jsdom: 19.0.0
       prettier: 2.5.1
-      yargs: 17.3.0
+      yargs: 17.3.1
     devDependencies:
-      '@antfu/eslint-config': 0.14.0_eslint@8.5.0+typescript@4.5.4
+      '@antfu/eslint-config': 0.14.2_eslint@8.5.0+typescript@4.5.4
       '@types/fs-extra': 9.0.13
-      '@types/html-minifier': 4.0.1
-      '@types/jsdom': 16.2.13
+      '@types/html-minifier': 4.0.2
+      '@types/jsdom': 16.2.14
       '@types/prettier': 2.4.2
-      '@types/yargs': 17.0.7
-      '@typescript-eslint/eslint-plugin': 5.7.0_eslint@8.5.0+typescript@4.5.4
+      '@types/yargs': 17.0.8
+      '@typescript-eslint/eslint-plugin': 5.8.1_eslint@8.5.0+typescript@4.5.4
       '@vueuse/head': 0.7.4_vue@3.2.26
       bumpp: 7.1.1
       critters: 0.0.15
       eslint: 8.5.0
       esno: 0.13.0_typescript@4.5.4
-      rollup: 2.61.1
+      rollup: 2.62.0
       standard-version: 9.3.2
-      tsup: 5.11.6_typescript@4.5.4
+      tsup: 5.11.9_typescript@4.5.4
       typescript: 4.5.4
-      vite: 2.7.3
-      vite-plugin-pwa: 0.11.12_vite@2.7.3
+      vite: 2.7.10
+      vite-plugin-pwa: 0.11.12_vite@2.7.10
       vue: 3.2.26
       vue-router: 4.0.12_vue@3.2.26
 
   examples/multiple-pages:
     specifiers:
-      '@vitejs/plugin-vue': ^1.9.4
+      '@vitejs/plugin-vue': ^2.0.1
       cross-env: ^7.0.3
-      typescript: ^4.4.4
-      vite: ^2.6.14
+      typescript: ^4.5.4
+      vite: ^2.7.10
       vite-plugin-components: ^0.13.3
-      vite-plugin-md: ^0.11.4
-      vite-plugin-pages: ^0.18.2
+      vite-plugin-md: ^0.11.7
+      vite-plugin-pages: ^0.19.8
       vite-ssg: workspace:*
-      vue: ^3.2.22
+      vue: ^3.2.26
       vue-router: ^4.0.12
     dependencies:
-      vue: 3.2.22
+      vue: 3.2.26
     devDependencies:
-      '@vitejs/plugin-vue': 1.9.4_vite@2.6.14
+      '@vitejs/plugin-vue': 2.0.1_vite@2.7.10+vue@3.2.26
       cross-env: 7.0.3
-      typescript: 4.4.4
-      vite: 2.6.14
-      vite-plugin-components: 0.13.3_vite@2.6.14
-      vite-plugin-md: 0.11.4_vite@2.6.14
-      vite-plugin-pages: 0.18.2_vite@2.6.14
+      typescript: 4.5.4
+      vite: 2.7.10
+      vite-plugin-components: 0.13.3_vite@2.7.10
+      vite-plugin-md: 0.11.7_vite@2.7.10
+      vite-plugin-pages: 0.19.8_vite@2.7.10
       vite-ssg: link:../..
-      vue-router: 4.0.12_vue@3.2.22
+      vue-router: 4.0.12_vue@3.2.26
 
   examples/multiple-pages-pwa:
     specifiers:
-      '@vitejs/plugin-vue': ^1.9.4
+      '@vitejs/plugin-vue': ^2.0.1
       cross-env: ^7.0.3
-      typescript: ^4.4.4
-      vite: ^2.6.14
+      typescript: ^4.5.4
+      vite: ^2.7.10
       vite-plugin-components: ^0.13.3
-      vite-plugin-md: ^0.11.4
-      vite-plugin-pages: ^0.18.2
-      vite-plugin-pwa: ^0.11.5
+      vite-plugin-md: ^0.11.7
+      vite-plugin-pages: ^0.19.8
+      vite-plugin-pwa: ^0.11.12
       vite-ssg: workspace:*
-      vue: ^3.2.22
+      vue: ^3.2.26
       vue-router: ^4.0.12
     dependencies:
-      vue: 3.2.22
+      vue: 3.2.26
     devDependencies:
-      '@vitejs/plugin-vue': 1.9.4_vite@2.6.14
+      '@vitejs/plugin-vue': 2.0.1_vite@2.7.10+vue@3.2.26
       cross-env: 7.0.3
-      typescript: 4.4.4
-      vite: 2.6.14
-      vite-plugin-components: 0.13.3_vite@2.6.14
-      vite-plugin-md: 0.11.4_vite@2.6.14
-      vite-plugin-pages: 0.18.2_vite@2.6.14
-      vite-plugin-pwa: 0.11.5_vite@2.6.14
+      typescript: 4.5.4
+      vite: 2.7.10
+      vite-plugin-components: 0.13.3_vite@2.7.10
+      vite-plugin-md: 0.11.7_vite@2.7.10
+      vite-plugin-pages: 0.19.8_vite@2.7.10
+      vite-plugin-pwa: 0.11.12_vite@2.7.10
       vite-ssg: link:../..
-      vue-router: 4.0.12_vue@3.2.22
+      vue-router: 4.0.12_vue@3.2.26
 
   examples/multiple-pages-with-store:
     specifiers:
       '@nuxt/devalue': ^2.0.0
-      '@vitejs/plugin-vue': ^1.9.4
+      '@vitejs/plugin-vue': ^2.0.1
       cross-env: ^7.0.3
-      pinia: 2.0.3
-      typescript: ^4.4.4
-      vite: ^2.6.14
+      pinia: 2.0.9
+      typescript: ^4.5.4
+      vite: ^2.7.10
       vite-plugin-components: ^0.13.3
-      vite-plugin-md: ^0.11.4
-      vite-plugin-pages: ^0.18.2
+      vite-plugin-md: ^0.11.7
+      vite-plugin-pages: ^0.19.8
       vite-ssg: workspace:*
-      vue: ^3.2.22
+      vue: ^3.2.26
       vue-router: ^4.0.12
     dependencies:
-      pinia: 2.0.3_typescript@4.4.4+vue@3.2.22
-      vue: 3.2.22
+      pinia: 2.0.9_typescript@4.5.4+vue@3.2.26
+      vue: 3.2.26
     devDependencies:
       '@nuxt/devalue': 2.0.0
-      '@vitejs/plugin-vue': 1.9.4_vite@2.6.14
+      '@vitejs/plugin-vue': 2.0.1_vite@2.7.10+vue@3.2.26
       cross-env: 7.0.3
-      typescript: 4.4.4
-      vite: 2.6.14
-      vite-plugin-components: 0.13.3_vite@2.6.14
-      vite-plugin-md: 0.11.4_vite@2.6.14
-      vite-plugin-pages: 0.18.2_vite@2.6.14
+      typescript: 4.5.4
+      vite: 2.7.10
+      vite-plugin-components: 0.13.3_vite@2.7.10
+      vite-plugin-md: 0.11.7_vite@2.7.10
+      vite-plugin-pages: 0.19.8_vite@2.7.10
       vite-ssg: link:../..
-      vue-router: 4.0.12_vue@3.2.22
+      vue-router: 4.0.12_vue@3.2.26
 
   examples/single-page:
     specifiers:
-      '@vitejs/plugin-vue': ^1.9.4
+      '@vitejs/plugin-vue': ^2.0.1
       cross-env: ^7.0.3
-      pinia: ^2.0.3
-      typescript: ^4.4.4
-      vite: ^2.6.14
+      pinia: ^2.0.9
+      typescript: ^4.5.4
+      vite: ^2.7.10
       vite-ssg: workspace:*
-      vue: ^3.2.22
+      vue: ^3.2.26
     dependencies:
-      pinia: 2.0.3_typescript@4.4.4+vue@3.2.22
-      vue: 3.2.22
+      pinia: 2.0.9_typescript@4.5.4+vue@3.2.26
+      vue: 3.2.26
     devDependencies:
-      '@vitejs/plugin-vue': 1.9.4_vite@2.6.14
+      '@vitejs/plugin-vue': 2.0.1_vite@2.7.10+vue@3.2.26
       cross-env: 7.0.3
-      typescript: 4.4.4
-      vite: 2.6.14
+      typescript: 4.5.4
+      vite: 2.7.10
       vite-ssg: link:../..
 
 packages:
 
-  /@antfu/eslint-config-basic/0.14.0_eslint@8.5.0:
-    resolution: {integrity: sha512-H5+pLZK9CvLuyNrUknymyocgW1J3MKppGmCG4FekmYAAu52VJFQ9sP/ehfbswVMSvU5VfLguV6E8n5BmL3r9/A==}
+  /@antfu/eslint-config-basic/0.14.2_eslint@8.5.0:
+    resolution: {integrity: sha512-NFcItSFfMQIINPDDrY2xL9UcR7kWcjWoGw1ETV3wN2sLqfKL2DNVxpKKlHfXk7EalNFOkMYih3shym36T7SuXg==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
       eslint: 8.5.0
-      eslint-config-standard: 16.0.3_72c8a59d61ea280e4bd230741483b2d1
+      eslint-config-standard: 16.0.3_4cecef3480376bac71ded249816d1e72
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.5.0
       eslint-plugin-html: 6.2.0
       eslint-plugin-import: 2.25.3_eslint@8.5.0
       eslint-plugin-jsonc: 2.0.0_eslint@8.5.0
       eslint-plugin-node: 11.1.0_eslint@8.5.0
-      eslint-plugin-promise: 5.2.0_eslint@8.5.0
+      eslint-plugin-promise: 6.0.0_eslint@8.5.0
       eslint-plugin-unicorn: 39.0.0_eslint@8.5.0
       eslint-plugin-yml: 0.12.0_eslint@8.5.0
       jsonc-eslint-parser: 2.0.4_eslint@8.5.0
@@ -182,66 +182,66 @@ packages:
       - supports-color
     dev: true
 
-  /@antfu/eslint-config-react/0.14.0_eslint@8.5.0+typescript@4.5.4:
-    resolution: {integrity: sha512-cbbuebmWFP2nbylXfOWnkUjNIkUUqqtFm7ShtBrmvZOz9HOrle2cfCtjiwtasl6hT6aUjTqbg50k9iCk90pv9g==}
+  /@antfu/eslint-config-react/0.14.2_eslint@8.5.0+typescript@4.5.4:
+    resolution: {integrity: sha512-RqQErQMP4JJbHaHgfNg8y9TohNC2KoUPsSWxenFklDsw0G5fAvCOpASHZaSdWlpm7ndR4ewdSMqEuPx6UCrEpQ==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-ts': 0.14.0_eslint@8.5.0+typescript@4.5.4
+      '@antfu/eslint-config-ts': 0.14.2_eslint@8.5.0+typescript@4.5.4
       eslint: 8.5.0
-      eslint-plugin-react: 7.27.1_eslint@8.5.0
+      eslint-plugin-react: 7.28.0_eslint@8.5.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@antfu/eslint-config-ts/0.14.0_eslint@8.5.0+typescript@4.5.4:
-    resolution: {integrity: sha512-47a83IB10WEiWvh8XCTFmOIZ1NcgIXhY6H2PciYZut2B4lIMwdAak4mY/PBgGxzxIy4D+g9uEmKvlSKpCabb1Q==}
+  /@antfu/eslint-config-ts/0.14.2_eslint@8.5.0+typescript@4.5.4:
+    resolution: {integrity: sha512-vD1ufmbXQYH0mb4D8opkGqvr3XJWTnP6gmTK4uHA1s9agX663wQ7cgEV61pYDrUoQXgB8b651p5vb2hBVzAhOA==}
     peerDependencies:
       eslint: '>=7.4.0'
       typescript: '>=3.9'
     dependencies:
-      '@antfu/eslint-config-basic': 0.14.0_eslint@8.5.0
-      '@typescript-eslint/eslint-plugin': 5.7.0_a6f6159640504abdd3de077f8bcadb33
-      '@typescript-eslint/parser': 5.7.0_eslint@8.5.0+typescript@4.5.4
+      '@antfu/eslint-config-basic': 0.14.2_eslint@8.5.0
+      '@typescript-eslint/eslint-plugin': 5.8.1_3a47348159e115370aa4cba56aba33b6
+      '@typescript-eslint/parser': 5.8.1_eslint@8.5.0+typescript@4.5.4
       eslint: 8.5.0
       typescript: 4.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@antfu/eslint-config-vue/0.14.0_eslint@8.5.0+typescript@4.5.4:
-    resolution: {integrity: sha512-NkOmwIIPZI5N1xMrDoP6Yi3ZHSYVZVPDIbpHZ3J3EhqnyehI6dHSTvqKd58c4sb4Ck8Z/TBJZtt6Xnd98ApS1w==}
+  /@antfu/eslint-config-vue/0.14.2_eslint@8.5.0+typescript@4.5.4:
+    resolution: {integrity: sha512-35Wi2BC6wMLJ9cYkCqetzhCSZeKX1USEjD1yLOKQXe+agoNVgG+6zPYobSTs9HdmR3z1ZtbPIee1v6tfC4csmA==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-ts': 0.14.0_eslint@8.5.0+typescript@4.5.4
+      '@antfu/eslint-config-ts': 0.14.2_eslint@8.5.0+typescript@4.5.4
       eslint: 8.5.0
-      eslint-plugin-vue: 8.1.1_eslint@8.5.0
+      eslint-plugin-vue: 8.2.0_eslint@8.5.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@antfu/eslint-config/0.14.0_eslint@8.5.0+typescript@4.5.4:
-    resolution: {integrity: sha512-Q3/qs7ZGRz8+om0YuKziD0WyxutESc+hl9daDaZ9ubkwYu3FfrPN8v1tV9wXBn3DBWkeBDgnG++HPTs7i2O7fA==}
+  /@antfu/eslint-config/0.14.2_eslint@8.5.0+typescript@4.5.4:
+    resolution: {integrity: sha512-nsYORILfN9uq94FbM8uCYHCAN+qIRoodwpBSSqfPb+gaYBjCo1P5UKVk4s1OoWQwzfD5UNjJOkOtS7cMjcb4cA==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-react': 0.14.0_eslint@8.5.0+typescript@4.5.4
-      '@antfu/eslint-config-vue': 0.14.0_eslint@8.5.0+typescript@4.5.4
-      '@typescript-eslint/eslint-plugin': 5.7.0_a6f6159640504abdd3de077f8bcadb33
-      '@typescript-eslint/parser': 5.7.0_eslint@8.5.0+typescript@4.5.4
+      '@antfu/eslint-config-react': 0.14.2_eslint@8.5.0+typescript@4.5.4
+      '@antfu/eslint-config-vue': 0.14.2_eslint@8.5.0+typescript@4.5.4
+      '@typescript-eslint/eslint-plugin': 5.8.1_3a47348159e115370aa4cba56aba33b6
+      '@typescript-eslint/parser': 5.8.1_eslint@8.5.0+typescript@4.5.4
       eslint: 8.5.0
-      eslint-config-standard: 16.0.3_72c8a59d61ea280e4bd230741483b2d1
+      eslint-config-standard: 16.0.3_4cecef3480376bac71ded249816d1e72
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.5.0
       eslint-plugin-html: 6.2.0
       eslint-plugin-import: 2.25.3_eslint@8.5.0
       eslint-plugin-jsonc: 2.0.0_eslint@8.5.0
       eslint-plugin-node: 11.1.0_eslint@8.5.0
-      eslint-plugin-promise: 5.2.0_eslint@8.5.0
+      eslint-plugin-promise: 6.0.0_eslint@8.5.0
       eslint-plugin-unicorn: 39.0.0_eslint@8.5.0
-      eslint-plugin-vue: 8.1.1_eslint@8.5.0
+      eslint-plugin-vue: 8.2.0_eslint@8.5.0
       eslint-plugin-yml: 0.12.0_eslint@8.5.0
       jsonc-eslint-parser: 2.0.4_eslint@8.5.0
       yaml-eslint-parser: 0.5.0
@@ -254,18 +254,6 @@ packages:
     resolution: {integrity: sha512-UU8TLr/EoXdg7OjMp0h9oDoIAVr+Z/oW9cpOxQQyrsz6Qzd2ms/1CdWx8fl2OQdFpxGmq5Vc4TwfLHId6nAZjA==}
     dependencies:
       '@types/throttle-debounce': 2.1.0
-    dev: true
-
-  /@apideck/better-ajv-errors/0.2.7_ajv@8.6.2:
-    resolution: {integrity: sha512-J2dW+EHYudbwI7MGovcHWLBrxasl21uuroc2zT8bH2RxYuv2g5GqsO5jcKUZz4LaMST45xhKjVuyRYkhcWyMhA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      ajv: '>=8'
-    dependencies:
-      ajv: 8.6.2
-      json-schema: 0.3.0
-      jsonpointer: 5.0.0
-      leven: 3.1.0
     dev: true
 
   /@apideck/better-ajv-errors/0.3.1_ajv@8.6.2:
@@ -306,7 +294,7 @@ packages:
       '@babel/traverse': 7.14.8
       '@babel/types': 7.14.8
       convert-source-map: 1.8.0
-      debug: 4.3.2
+      debug: 4.3.3
       gensync: 1.0.0-beta.2
       json5: 2.2.0
       semver: 6.3.0
@@ -404,7 +392,7 @@ packages:
       '@babel/helper-module-imports': 7.14.5
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/traverse': 7.14.8
-      debug: 4.3.2
+      debug: 4.3.3
       lodash.debounce: 4.0.8
       resolve: 1.20.0
       semver: 6.3.0
@@ -574,12 +562,12 @@ packages:
     resolution: {integrity: sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dev: true
 
   /@babel/parser/7.16.6:
     resolution: {integrity: sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dev: true
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.14.5_@babel+core@7.14.8:
     resolution: {integrity: sha512-ZoJS2XCKPBfTmL122iP6NM9dOg+d4lc9fFk3zxc8iDjvt8Pk4+TlsHSKhIPf6X+L5ORCdBzqMZDjL/WHj7WknQ==}
@@ -1387,7 +1375,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.14.5
       '@babel/parser': 7.15.3
       '@babel/types': 7.14.8
-      debug: 4.3.2
+      debug: 4.3.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1468,7 +1456,7 @@ packages:
     resolution: {integrity: sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==}
     dev: true
 
-  /@rollup/plugin-babel/5.3.0_@babel+core@7.14.8+rollup@2.60.0:
+  /@rollup/plugin-babel/5.3.0_@babel+core@7.14.8+rollup@2.62.0:
     resolution: {integrity: sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -1481,78 +1469,36 @@ packages:
     dependencies:
       '@babel/core': 7.14.8
       '@babel/helper-module-imports': 7.14.5
-      '@rollup/pluginutils': 3.1.0_rollup@2.60.0
-      rollup: 2.60.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.62.0
+      rollup: 2.62.0
     dev: true
 
-  /@rollup/plugin-babel/5.3.0_@babel+core@7.14.8+rollup@2.61.1:
-    resolution: {integrity: sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==}
-    engines: {node: '>= 10.0.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/babel__core': ^7.1.9
-      rollup: ^1.20.0||^2.0.0
-    peerDependenciesMeta:
-      '@types/babel__core':
-        optional: true
-    dependencies:
-      '@babel/core': 7.14.8
-      '@babel/helper-module-imports': 7.14.5
-      '@rollup/pluginutils': 3.1.0_rollup@2.61.1
-      rollup: 2.61.1
-    dev: true
-
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.60.0:
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.62.0:
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.60.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.62.0
       '@types/resolve': 1.17.1
       builtin-modules: 3.2.0
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.20.0
-      rollup: 2.60.0
+      rollup: 2.62.0
     dev: true
 
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.61.1:
-    resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
-    engines: {node: '>= 10.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.61.1
-      '@types/resolve': 1.17.1
-      builtin-modules: 3.2.0
-      deepmerge: 4.2.2
-      is-module: 1.0.0
-      resolve: 1.20.0
-      rollup: 2.61.1
-    dev: true
-
-  /@rollup/plugin-replace/2.4.2_rollup@2.60.0:
+  /@rollup/plugin-replace/2.4.2_rollup@2.62.0:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.60.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.62.0
       magic-string: 0.25.7
-      rollup: 2.60.0
+      rollup: 2.62.0
     dev: true
 
-  /@rollup/plugin-replace/2.4.2_rollup@2.61.1:
-    resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
-    peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.61.1
-      magic-string: 0.25.7
-      rollup: 2.61.1
-    dev: true
-
-  /@rollup/pluginutils/3.1.0_rollup@2.60.0:
+  /@rollup/pluginutils/3.1.0_rollup@2.62.0:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -1561,23 +1507,11 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.0
-      rollup: 2.60.0
+      rollup: 2.62.0
     dev: true
 
-  /@rollup/pluginutils/3.1.0_rollup@2.61.1:
-    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    dependencies:
-      '@types/estree': 0.0.39
-      estree-walker: 1.0.1
-      picomatch: 2.3.0
-      rollup: 2.61.1
-    dev: true
-
-  /@rollup/pluginutils/4.1.1:
-    resolution: {integrity: sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==}
+  /@rollup/pluginutils/4.1.2:
+    resolution: {integrity: sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==}
     engines: {node: '>= 8.0.0'}
     dependencies:
       estree-walker: 2.0.2
@@ -1615,18 +1549,18 @@ packages:
       '@types/node': 16.4.8
     dev: true
 
-  /@types/html-minifier/4.0.1:
-    resolution: {integrity: sha512-6u58FWQbWP45bsxVeMJo0yk2LEsjjZsCwn0JDe/i5Edk3L+b9TR5eZ2FGaMCrLdtGYpME5AGxUqv8o+3hWKogw==}
+  /@types/html-minifier/4.0.2:
+    resolution: {integrity: sha512-4IkmkXJP/25R2fZsCHDX2abztXuQRzUAZq39PfCMz2loLFj8vS9y7aF6vDl58koXSTpsF+eL4Lc5Y4Aww/GCTQ==}
     dependencies:
       '@types/clean-css': 4.2.5
       '@types/relateurl': 0.2.29
       '@types/uglify-js': 3.13.1
     dev: true
 
-  /@types/jsdom/16.2.13:
-    resolution: {integrity: sha512-8JQCjdeAidptSsOcRWk2iTm9wCcwn9l+kRG6k5bzUacrnm1ezV4forq0kWjUih/tumAeoG+OspOvQEbbRucBTw==}
+  /@types/jsdom/16.2.14:
+    resolution: {integrity: sha512-6BAy1xXEmMuHeAJ4Fv4yXKwBDTGTOseExKE3OaHiNycdHdZw59KfYzrt0DkDluvwmik1HRt6QS7bImxUmpSy+w==}
     dependencies:
-      '@types/node': 15.3.0
+      '@types/node': 16.4.8
       '@types/parse5': 6.0.0
       '@types/tough-cookie': 4.0.0
     dev: true
@@ -1656,10 +1590,6 @@ packages:
 
   /@types/minimist/1.2.1:
     resolution: {integrity: sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==}
-    dev: true
-
-  /@types/node/15.3.0:
-    resolution: {integrity: sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==}
     dev: true
 
   /@types/node/16.4.8:
@@ -1714,14 +1644,14 @@ packages:
     resolution: {integrity: sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==}
     dev: true
 
-  /@types/yargs/17.0.7:
-    resolution: {integrity: sha512-OvLKmpKdea1aWtqHv9bxVVcMoT6syAeK+198dfETIFkAevYRGwqh4H+KFxfjUETZuUuE5sQCAFwdOdoHUdo8eg==}
+  /@types/yargs/17.0.8:
+    resolution: {integrity: sha512-wDeUwiUmem9FzsyysEwRukaEdDNcwbROvQ9QGRKaLI6t+IltNzbn4/i4asmB10auvZGQCzSQ6t0GSczEThlUXw==}
     dependencies:
       '@types/yargs-parser': 20.2.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.7.0_a6f6159640504abdd3de077f8bcadb33:
-    resolution: {integrity: sha512-8RTGBpNn5a9M628wBPrCbJ+v3YTEOE2qeZb7TDkGKTDXSj36KGRg92SpFFaR/0S3rSXQxM0Og/kV9EyadsYSBg==}
+  /@typescript-eslint/eslint-plugin/5.8.1_3a47348159e115370aa4cba56aba33b6:
+    resolution: {integrity: sha512-wTZ5oEKrKj/8/366qTM366zqhIKAp6NCMweoRONtfuC07OAU9nVI2GZZdqQ1qD30WAAtcPdkH+npDwtRFdp4Rw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -1731,9 +1661,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.7.0_eslint@8.5.0+typescript@4.5.4
-      '@typescript-eslint/parser': 5.7.0_eslint@8.5.0+typescript@4.5.4
-      '@typescript-eslint/scope-manager': 5.7.0
+      '@typescript-eslint/experimental-utils': 5.8.1_eslint@8.5.0+typescript@4.5.4
+      '@typescript-eslint/parser': 5.8.1_eslint@8.5.0+typescript@4.5.4
+      '@typescript-eslint/scope-manager': 5.8.1
       debug: 4.3.3
       eslint: 8.5.0
       functional-red-black-tree: 1.0.1
@@ -1746,8 +1676,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.7.0_eslint@8.5.0+typescript@4.5.4:
-    resolution: {integrity: sha512-8RTGBpNn5a9M628wBPrCbJ+v3YTEOE2qeZb7TDkGKTDXSj36KGRg92SpFFaR/0S3rSXQxM0Og/kV9EyadsYSBg==}
+  /@typescript-eslint/eslint-plugin/5.8.1_eslint@8.5.0+typescript@4.5.4:
+    resolution: {integrity: sha512-wTZ5oEKrKj/8/366qTM366zqhIKAp6NCMweoRONtfuC07OAU9nVI2GZZdqQ1qD30WAAtcPdkH+npDwtRFdp4Rw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -1757,8 +1687,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.7.0_eslint@8.5.0+typescript@4.5.4
-      '@typescript-eslint/scope-manager': 5.7.0
+      '@typescript-eslint/experimental-utils': 5.8.1_eslint@8.5.0+typescript@4.5.4
+      '@typescript-eslint/scope-manager': 5.8.1
       debug: 4.3.3
       eslint: 8.5.0
       functional-red-black-tree: 1.0.1
@@ -1771,16 +1701,16 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.7.0_eslint@8.5.0+typescript@4.5.4:
-    resolution: {integrity: sha512-u57eZ5FbEpzN5kSjmVrSesovWslH2ZyNPnaXQMXWgH57d5+EVHEt76W75vVuI9qKZ5BMDKNfRN+pxcPEjQjb2A==}
+  /@typescript-eslint/experimental-utils/5.8.1_eslint@8.5.0+typescript@4.5.4:
+    resolution: {integrity: sha512-fbodVnjIDU4JpeXWRDsG5IfIjYBxEvs8EBO8W1+YVdtrc2B9ppfof5sZhVEDOtgTfFHnYQJDI8+qdqLYO4ceww==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.7.0
-      '@typescript-eslint/types': 5.7.0
-      '@typescript-eslint/typescript-estree': 5.7.0_typescript@4.5.4
+      '@typescript-eslint/scope-manager': 5.8.1
+      '@typescript-eslint/types': 5.8.1
+      '@typescript-eslint/typescript-estree': 5.8.1_typescript@4.5.4
       eslint: 8.5.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.5.0
@@ -1789,8 +1719,8 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.7.0_eslint@8.5.0+typescript@4.5.4:
-    resolution: {integrity: sha512-m/gWCCcS4jXw6vkrPQ1BjZ1vomP01PArgzvauBqzsoZ3urLbsRChexB8/YV8z9HwE3qlJM35FxfKZ1nfP/4x8g==}
+  /@typescript-eslint/parser/5.8.1_eslint@8.5.0+typescript@4.5.4:
+    resolution: {integrity: sha512-K1giKHAjHuyB421SoXMXFHHVI4NdNY603uKw92++D3qyxSeYvC10CBJ/GE5Thpo4WTUvu1mmJI2/FFkz38F2Gw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1799,9 +1729,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.7.0
-      '@typescript-eslint/types': 5.7.0
-      '@typescript-eslint/typescript-estree': 5.7.0_typescript@4.5.4
+      '@typescript-eslint/scope-manager': 5.8.1
+      '@typescript-eslint/types': 5.8.1
+      '@typescript-eslint/typescript-estree': 5.8.1_typescript@4.5.4
       debug: 4.3.3
       eslint: 8.5.0
       typescript: 4.5.4
@@ -1809,21 +1739,21 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.7.0:
-    resolution: {integrity: sha512-7mxR520DGq5F7sSSgM0HSSMJ+TFUymOeFRMfUfGFAVBv8BR+Jv1vHgAouYUvWRZeszVBJlLcc9fDdktxb5kmxA==}
+  /@typescript-eslint/scope-manager/5.8.1:
+    resolution: {integrity: sha512-DGxJkNyYruFH3NIZc3PwrzwOQAg7vvgsHsHCILOLvUpupgkwDZdNq/cXU3BjF4LNrCsVg0qxEyWasys5AiJ85Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.7.0
-      '@typescript-eslint/visitor-keys': 5.7.0
+      '@typescript-eslint/types': 5.8.1
+      '@typescript-eslint/visitor-keys': 5.8.1
     dev: true
 
-  /@typescript-eslint/types/5.7.0:
-    resolution: {integrity: sha512-5AeYIF5p2kAneIpnLFve8g50VyAjq7udM7ApZZ9JYjdPjkz0LvODfuSHIDUVnIuUoxafoWzpFyU7Sqbxgi79mA==}
+  /@typescript-eslint/types/5.8.1:
+    resolution: {integrity: sha512-L/FlWCCgnjKOLefdok90/pqInkomLnAcF9UAzNr+DSqMC3IffzumHTQTrINXhP1gVp9zlHiYYjvozVZDPleLcA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.7.0_typescript@4.5.4:
-    resolution: {integrity: sha512-aO1Ql+izMrTnPj5aFFlEJkpD4jRqC4Gwhygu2oHK2wfVQpmOPbyDSveJ+r/NQo+PWV43M6uEAeLVbTi09dFLhg==}
+  /@typescript-eslint/typescript-estree/5.8.1_typescript@4.5.4:
+    resolution: {integrity: sha512-26lQ8l8tTbG7ri7xEcCFT9ijU5Fk+sx/KRRyyzCv7MQ+rZZlqiDPtMKWLC8P7o+dtCnby4c+OlxuX1tp8WfafQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -1831,8 +1761,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.7.0
-      '@typescript-eslint/visitor-keys': 5.7.0
+      '@typescript-eslint/types': 5.8.1
+      '@typescript-eslint/visitor-keys': 5.8.1
       debug: 4.3.3
       globby: 11.0.4
       is-glob: 4.0.3
@@ -1843,31 +1773,24 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.7.0:
-    resolution: {integrity: sha512-hdohahZ4lTFcglZSJ3DGdzxQHBSxsLVqHzkiOmKi7xVAWC4y2c1bIMKmPJSrA4aOEoRUPOKQ87Y/taC7yVHpFg==}
+  /@typescript-eslint/visitor-keys/5.8.1:
+    resolution: {integrity: sha512-SWgiWIwocK6NralrJarPZlWdr0hZnj5GXHIgfdm8hNkyKvpeQuFyLP6YjSIe9kf3YBIfU6OHSZLYkQ+smZwtNg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.7.0
+      '@typescript-eslint/types': 5.8.1
       eslint-visitor-keys: 3.1.0
     dev: true
 
-  /@vitejs/plugin-vue/1.9.4_vite@2.6.14:
-    resolution: {integrity: sha512-0CZqaCoChriPTTtGkERy1LGPcYjGFpi2uYRhBPIkqJqUGV5JnJFhQAgh6oH9j5XZHfrRaisX8W0xSpO4T7S78A==}
+  /@vitejs/plugin-vue/2.0.1_vite@2.7.10+vue@3.2.26:
+    resolution: {integrity: sha512-wtdMnGVvys9K8tg+DxowU1ytTrdVveXr3LzdhaKakysgGXyrsfaeds2cDywtvujEASjWOwWL/OgWM+qoeM8Plg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       vite: ^2.5.10
+      vue: ^3.2.25
     dependencies:
-      vite: 2.6.14
+      vite: 2.7.10
+      vue: 3.2.26
     dev: true
-
-  /@vue/compiler-core/3.2.22:
-    resolution: {integrity: sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==}
-    dependencies:
-      '@babel/parser': 7.15.3
-      '@vue/shared': 3.2.22
-      estree-walker: 2.0.2
-      source-map: 0.6.1
-    dev: false
 
   /@vue/compiler-core/3.2.26:
     resolution: {integrity: sha512-N5XNBobZbaASdzY9Lga2D9Lul5vdCIOXvUMd6ThcN8zgqQhPKfCV+wfAJNNJKQkSHudnYRO2gEB+lp0iN3g2Tw==}
@@ -1876,36 +1799,12 @@ packages:
       '@vue/shared': 3.2.26
       estree-walker: 2.0.2
       source-map: 0.6.1
-    dev: true
-
-  /@vue/compiler-dom/3.2.22:
-    resolution: {integrity: sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==}
-    dependencies:
-      '@vue/compiler-core': 3.2.22
-      '@vue/shared': 3.2.22
-    dev: false
 
   /@vue/compiler-dom/3.2.26:
     resolution: {integrity: sha512-smBfaOW6mQDxcT3p9TKT6mE22vjxjJL50GFVJiI0chXYGU/xzC05QRGrW3HHVuJrmLTLx5zBhsZ2dIATERbarg==}
     dependencies:
       '@vue/compiler-core': 3.2.26
       '@vue/shared': 3.2.26
-    dev: true
-
-  /@vue/compiler-sfc/3.2.22:
-    resolution: {integrity: sha512-tWRQ5ge1tsTDhUwHgueicKJ8rYm6WUVAPTaIpFW3GSwZKcOEJ2rXdfkHFShNVGupeRALz2ET2H84OL0GeRxY0A==}
-    dependencies:
-      '@babel/parser': 7.15.3
-      '@vue/compiler-core': 3.2.22
-      '@vue/compiler-dom': 3.2.22
-      '@vue/compiler-ssr': 3.2.22
-      '@vue/ref-transform': 3.2.22
-      '@vue/shared': 3.2.22
-      estree-walker: 2.0.2
-      magic-string: 0.25.7
-      postcss: 8.3.9
-      source-map: 0.6.1
-    dev: false
 
   /@vue/compiler-sfc/3.2.26:
     resolution: {integrity: sha512-ePpnfktV90UcLdsDQUh2JdiTuhV0Skv2iYXxfNMOK/F3Q+2BO0AulcVcfoksOpTJGmhhfosWfMyEaEf0UaWpIw==}
@@ -1920,28 +1819,19 @@ packages:
       magic-string: 0.25.7
       postcss: 8.3.9
       source-map: 0.6.1
-    dev: true
-
-  /@vue/compiler-ssr/3.2.22:
-    resolution: {integrity: sha512-Cl6aoLJtXzzBkk1sKod8S0WBJLts3+ugVC91d22gGpbkw/64WnF12tOZi7Rg54PPLi1NovqyNWPsLH/SAFcu+w==}
-    dependencies:
-      '@vue/compiler-dom': 3.2.22
-      '@vue/shared': 3.2.22
-    dev: false
 
   /@vue/compiler-ssr/3.2.26:
     resolution: {integrity: sha512-2mywLX0ODc4Zn8qBoA2PDCsLEZfpUGZcyoFRLSOjyGGK6wDy2/5kyDOWtf0S0UvtoyVq95OTSGIALjZ4k2q/ag==}
     dependencies:
       '@vue/compiler-dom': 3.2.26
       '@vue/shared': 3.2.26
-    dev: true
 
   /@vue/devtools-api/6.0.0-beta.19:
     resolution: {integrity: sha512-ObzQhgkoVeoyKv+e8+tB/jQBL2smtk/NmC9OmFK8UqdDpoOdv/Kf9pyDWL+IFyM7qLD2C75rszJujvGSPSpGlw==}
     dev: true
 
-  /@vue/devtools-api/6.0.0-beta.20.1:
-    resolution: {integrity: sha512-R2rfiRY+kZugzWh9ZyITaovx+jpU4vgivAEAiz80kvh3yviiTU3CBuGuyWpSwGz9/C7TkSWVM/FtQRGlZ16n8Q==}
+  /@vue/devtools-api/6.0.0-beta.21.1:
+    resolution: {integrity: sha512-FqC4s3pm35qGVeXRGOjTsRzlkJjrBLriDS9YXbflHLsfA9FrcKzIyWnLXoNm+/7930E8rRakXuAc2QkC50swAw==}
     dev: false
 
   /@vue/reactivity-transform/3.2.26:
@@ -1952,51 +1842,17 @@ packages:
       '@vue/shared': 3.2.26
       estree-walker: 2.0.2
       magic-string: 0.25.7
-    dev: true
-
-  /@vue/reactivity/3.2.22:
-    resolution: {integrity: sha512-xNkLAItjI0xB+lFeDgKCrSItmrHTaAzSnt8LmdSCPQnDyarmzbi/u4ESQnckWvlL7lSRKiEaOvblaNyqAa7OnQ==}
-    dependencies:
-      '@vue/shared': 3.2.22
-    dev: false
 
   /@vue/reactivity/3.2.26:
     resolution: {integrity: sha512-h38bxCZLW6oFJVDlCcAiUKFnXI8xP8d+eO0pcDxx+7dQfSPje2AO6M9S9QO6MrxQB7fGP0DH0dYQ8ksf6hrXKQ==}
     dependencies:
       '@vue/shared': 3.2.26
-    dev: true
-
-  /@vue/ref-transform/3.2.22:
-    resolution: {integrity: sha512-qalVWbq5xWWxLZ0L9OroBg/JZhzavQuCcDXblfErxyDEH6Xc5gIJ4feo1SVCICFzhAUgLgQTdSFLpgjBawbFpw==}
-    dependencies:
-      '@babel/parser': 7.15.3
-      '@vue/compiler-core': 3.2.22
-      '@vue/shared': 3.2.22
-      estree-walker: 2.0.2
-      magic-string: 0.25.7
-    dev: false
-
-  /@vue/runtime-core/3.2.22:
-    resolution: {integrity: sha512-e7WOC55wmHPvmoVUk9VBe/Z9k5bJfWJfVIlkUkiADJn0bOgQD29oh/GS14Kb3aEJXIHLI17Em6+HxNut1sIh7Q==}
-    dependencies:
-      '@vue/reactivity': 3.2.22
-      '@vue/shared': 3.2.22
-    dev: false
 
   /@vue/runtime-core/3.2.26:
     resolution: {integrity: sha512-BcYi7qZ9Nn+CJDJrHQ6Zsmxei2hDW0L6AB4vPvUQGBm2fZyC0GXd/4nVbyA2ubmuhctD5RbYY8L+5GUJszv9mQ==}
     dependencies:
       '@vue/reactivity': 3.2.26
       '@vue/shared': 3.2.26
-    dev: true
-
-  /@vue/runtime-dom/3.2.22:
-    resolution: {integrity: sha512-w7VHYJoliLRTLc5beN77wxuOjla4v9wr2FF22xpZFYBmH4U1V7HkYhoHc1BTuNghI15CXT1tNIMhibI1nrQgdw==}
-    dependencies:
-      '@vue/runtime-core': 3.2.22
-      '@vue/shared': 3.2.22
-      csstype: 2.6.17
-    dev: false
 
   /@vue/runtime-dom/3.2.26:
     resolution: {integrity: sha512-dY56UIiZI+gjc4e8JQBwAifljyexfVCkIAu/WX8snh8vSOt/gMSEGwPRcl2UpYpBYeyExV8WCbgvwWRNt9cHhQ==}
@@ -2004,17 +1860,6 @@ packages:
       '@vue/runtime-core': 3.2.26
       '@vue/shared': 3.2.26
       csstype: 2.6.17
-    dev: true
-
-  /@vue/server-renderer/3.2.22_vue@3.2.22:
-    resolution: {integrity: sha512-jCwbQgKPXiXoH9VS9F7K+gyEvEMrjutannwEZD1R8fQ9szmOTqC+RRbIY3Uf2ibQjZtZ8DV9a4FjxICvd9zZlQ==}
-    peerDependencies:
-      vue: 3.2.22
-    dependencies:
-      '@vue/compiler-ssr': 3.2.22
-      '@vue/shared': 3.2.22
-      vue: 3.2.22
-    dev: false
 
   /@vue/server-renderer/3.2.26_vue@3.2.26:
     resolution: {integrity: sha512-Jp5SggDUvvUYSBIvYEhy76t4nr1vapY/FIFloWmQzn7UxqaHrrBpbxrqPcTrSgGrcaglj0VBp22BKJNre4aA1w==}
@@ -2024,15 +1869,9 @@ packages:
       '@vue/compiler-ssr': 3.2.26
       '@vue/shared': 3.2.26
       vue: 3.2.26
-    dev: true
-
-  /@vue/shared/3.2.22:
-    resolution: {integrity: sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ==}
-    dev: false
 
   /@vue/shared/3.2.26:
     resolution: {integrity: sha512-vPV6Cq+NIWbH5pZu+V+2QHE9y1qfuTq49uNWw4f7FDEeZaDU2H2cx5jcUZOAKW7qTrUS4k6qZPbMy1x4N96nbA==}
-    dev: true
 
   /@vueuse/head/0.7.4_vue@3.2.26:
     resolution: {integrity: sha512-cmps+wrdgL77V72vtjU6kaAunkG6GhswaMIQoh7Twc52ql4/p7i1Amd31LqnnvNF/bfuvzcXgYvsH8I7kimZmA==}
@@ -2061,14 +1900,6 @@ packages:
       acorn-walk: 7.2.0
     dev: false
 
-  /acorn-jsx/5.3.1_acorn@8.5.0:
-    resolution: {integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 8.5.0
-    dev: true
-
   /acorn-jsx/5.3.1_acorn@8.6.0:
     resolution: {integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==}
     peerDependencies:
@@ -2092,6 +1923,7 @@ packages:
     resolution: {integrity: sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: false
 
   /acorn/8.6.0:
     resolution: {integrity: sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==}
@@ -2134,10 +1966,6 @@ packages:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
     engines: {node: '>=6'}
     dev: true
-
-  /ansi-regex/5.0.0:
-    resolution: {integrity: sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==}
-    engines: {node: '>=8'}
 
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2444,6 +2272,12 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
+
+  /chalk/5.0.0:
+    resolution: {integrity: sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
 
   /chokidar/3.5.1:
     resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
@@ -2482,7 +2316,7 @@ packages:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
     dependencies:
       string-width: 4.2.3
-      strip-ansi: 6.0.0
+      strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
   /color-convert/1.9.3:
@@ -3115,14 +2949,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-android-arm64/0.13.4:
-    resolution: {integrity: sha512-elDJt+jNyoHFId0/dKsuVYUPke3EcquIyUwzJCH17a3ERglN3A9aMBI5zbz+xNZ+FbaDNdpn0RaJHCFLbZX+fA==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-android-arm64/0.14.5:
     resolution: {integrity: sha512-Sl6ysm7OAZZz+X3Mv3tOPhjMuSxNmztgoXH4ZZ3Yhbje5emEY6qiTnv3vBSljDlUl/yGaIjqC44qlj8s8G71xA==}
     cpu: [arm64]
@@ -3133,14 +2959,6 @@ packages:
 
   /esbuild-darwin-64/0.13.14:
     resolution: {integrity: sha512-YmOhRns6QBNSjpVdTahi/yZ8dscx9ai7a6OY6z5ACgOuQuaQ2Qk2qgJ0/siZ6LgD0gJFMV8UINFV5oky5TFNQQ==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-64/0.13.4:
-    resolution: {integrity: sha512-zJQGyHRAdZUXlRzbN7W+7ykmEiGC+bq3Gc4GxKYjjWTgDRSEly98ym+vRNkDjXwXYD3gGzSwvH35+MiHAtWvLA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -3163,14 +2981,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-arm64/0.13.4:
-    resolution: {integrity: sha512-r8oYvAtqSGq8HNTZCAx4TdLE7jZiGhX9ooGi5AQAey37MA6XNaP8ZNlw9OCpcgpx3ryU2WctXwIqPzkHO7a8dg==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-darwin-arm64/0.14.5:
     resolution: {integrity: sha512-ugPOLgEQPoPLSqAFBajaczt+lcbUZR+V2fby3572h5jf/kFV6UL8LAZ1Ze58hcbKwfvbh4C09kp0PhqPgXKwOg==}
     cpu: [arm64]
@@ -3181,14 +2991,6 @@ packages:
 
   /esbuild-freebsd-64/0.13.14:
     resolution: {integrity: sha512-BKosI3jtvTfnmsCW37B1TyxMUjkRWKqopR0CE9AF2ratdpkxdR24Vpe3gLKNyWiZ7BE96/SO5/YfhbPUzY8wKw==}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-64/0.13.4:
-    resolution: {integrity: sha512-u9DRGkn09EN8+lCh6z7FKle7awi17PJRBuAKdRNgSo5ZrH/3m+mYaJK2PR2URHMpAfXiwJX341z231tSdVe3Yw==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
@@ -3211,14 +3013,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-arm64/0.13.4:
-    resolution: {integrity: sha512-q3B2k68Uf6gfjATjcK16DqxvjqRQkHL8aPoOfj4op+lSqegdXvBacB1d8jw8PxbWJ8JHpdTLdAVUYU80kotQXA==}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-freebsd-arm64/0.14.5:
     resolution: {integrity: sha512-M99NPu8hlirFo6Fgx0WfX6XxUFdGclUNv3MyyfDtTdNYbccMESwLSACGpE7HvJKWscdjaqajeMu2an9adGNfCw==}
     cpu: [arm64]
@@ -3229,14 +3023,6 @@ packages:
 
   /esbuild-linux-32/0.13.14:
     resolution: {integrity: sha512-a8rOnS1oWSfkkYWXoD2yXNV4BdbDKA7PNVQ1klqkY9SoSApL7io66w5H44mTLsfyw7G6Z2vLlaLI2nz9MMAowA==}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-32/0.13.4:
-    resolution: {integrity: sha512-UUYJPHSiKAO8KoN3Ls/iZtgDLZvK5HarES96aolDPWZnq9FLx4dIHM/x2z4Rxv9IYqQ/DxlPoE2Co1UPBIYYeA==}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
@@ -3259,14 +3045,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-64/0.13.4:
-    resolution: {integrity: sha512-+RnohAKiiUW4UHLGRkNR1AnENW1gCuDWuygEtd4jxTNPIoeC7lbXGor7rtgjj9AdUzFgOEvAXyNNX01kJ8NueQ==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-64/0.14.5:
     resolution: {integrity: sha512-T+OuYPlhytjj5DsvjUXizNjbV+/IrZiaDc9SNUfqiUOXHu0URFqchjhPVbBiBnWykCMJFB6pqNap2Oxth4iuYw==}
     cpu: [x64]
@@ -3277,14 +3055,6 @@ packages:
 
   /esbuild-linux-arm/0.13.14:
     resolution: {integrity: sha512-8chZE4pkKRvJ/M/iwsNQ1KqsRg2RyU5eT/x2flNt/f8F2TVrDreR7I0HEeCR50wLla3B1C3wTIOzQBmjuc6uWg==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm/0.13.4:
-    resolution: {integrity: sha512-BH5gKve4jglS7UPSsfwHSX79I5agC/lm4eKoRUEyo8lwQs89frQSRp2Xup+6SFQnxt3md5EsKcd2Dbkqeb3gPA==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -3307,14 +3077,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm64/0.13.4:
-    resolution: {integrity: sha512-+A188cAdd6QuSRxMIwRrWLjgphQA0LDAQ/ECVlrPVJwnx+1i64NjDZivoqPYLOTkSPIKntiWwMhhf0U5/RrPHQ==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-arm64/0.14.5:
     resolution: {integrity: sha512-ANOzoaH4kfbhEZT0EGY9g1tsZhDA+I0FRwBsj7D8pCU900pXF/l8YAOy5jWFQIb3vjG5+orFc5SqSzAKCisvTQ==}
     cpu: [arm64]
@@ -3331,14 +3093,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-mips64le/0.13.4:
-    resolution: {integrity: sha512-0xkwtPaUkG5xMTFGaQPe1AadSe5QAiQuD4Gix1O9k5Xo/U8xGIkw9UFUTvfEUeu71vFb6ZgsIacfP1NLoFjWNw==}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-mips64le/0.14.5:
     resolution: {integrity: sha512-sSmGfOUNNB2Nd3tzp1RHSxiJmM5/RUIEP5aAtH+PpOP7FPp15Jcfwq7UNBJ82KLN3SJcwhUeEfcCaUFBzbTKxg==}
     cpu: [mips64el]
@@ -3349,14 +3103,6 @@ packages:
 
   /esbuild-linux-ppc64le/0.13.14:
     resolution: {integrity: sha512-un7KMwS7fX1Un6BjfSZxTT8L5cV/8Uf4SAhM7WYy2XF8o8TI+uRxxD03svZnRNIPsN2J5cl6qV4n7Iwz+yhhVw==}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-ppc64le/0.13.4:
-    resolution: {integrity: sha512-E1+oJPP7A+j23GPo3CEpBhGwG1bni4B8IbTA3/3rvzjURwUMZdcN3Fhrz24rnjzdLSHmULtOE4VsbT42h1Om4Q==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
@@ -3404,14 +3150,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-openbsd-64/0.13.4:
-    resolution: {integrity: sha512-xEkI1o5HYxDzbv9jSox0EsDxpwraG09SRiKKv0W8pH6O3bt+zPSlnoK7+I7Q69tkvONkpIq5n2o+c55uq0X7cw==}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-openbsd-64/0.14.5:
     resolution: {integrity: sha512-RZzRUu1RYKextJgXkHhAsuhLDvm73YP/wogpUG9MaAGvKTxnKAKRuaw2zJfnbz8iBqBQB2no2PmpVBNbqUTQrw==}
     cpu: [x64]
@@ -3437,14 +3175,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-sunos-64/0.13.4:
-    resolution: {integrity: sha512-bjXUMcODMnB6hQicLBBmmnBl7OMDyVpFahKvHGXJfDChIi5udiIRKCmFUFIRn+AUAKVlfrofRKdyPC7kBsbvGQ==}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-sunos-64/0.14.5:
     resolution: {integrity: sha512-J2ffKsBBWscQlye+/giEgKsQCppwHHFqqt/sh+ojVF+DZy1ve6RpPGwXGcGF6IaZTAI9+Vk4eHleiQxb+PC9Yw==}
     cpu: [x64]
@@ -3455,14 +3185,6 @@ packages:
 
   /esbuild-windows-32/0.13.14:
     resolution: {integrity: sha512-GZa6mrx2rgfbH/5uHg0Rdw50TuOKbdoKCpEBitzmG5tsXBdce+cOL+iFO5joZc6fDVCLW3Y6tjxmSXRk/v20Hg==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-32/0.13.4:
-    resolution: {integrity: sha512-z4CH07pfyVY0XF98TCsGmLxKCl0kyvshKDbdpTekW9f2d+dJqn5mmoUyWhpSVJ0SfYWJg86FoD9nMbbaMVyGdg==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
@@ -3485,14 +3207,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-64/0.13.4:
-    resolution: {integrity: sha512-uVL11vORRPjocGLYam67rwFLd0LvkrHEs+JG+1oJN4UD9MQmNGZPa4gBHo6hDpF+kqRJ9kXgQSeDqUyRy0tj/Q==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-windows-64/0.14.5:
     resolution: {integrity: sha512-ZM9rlBDsPEeMVJ1wcpNMXUad9VzYOFeOBUXBi+16HZTvFPy2DkcC2ZWcrByP3IESToD5lvHdjSX/w8rxphjqig==}
     cpu: [x64]
@@ -3503,14 +3217,6 @@ packages:
 
   /esbuild-windows-arm64/0.13.14:
     resolution: {integrity: sha512-KP8FHVlWGhM7nzYtURsGnskXb/cBCPTfj0gOKfjKq2tHtYnhDZywsUG57nk7TKhhK0fL11LcejHG3LRW9RF/9A==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-arm64/0.13.4:
-    resolution: {integrity: sha512-vA6GLvptgftRcDcWngD5cMlL4f4LbL8JjU2UMT9yJ0MT5ra6hdZNFWnOeOoEtY4GtJ6OjZ0i+81sTqhAB0fMkg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -3547,29 +3253,6 @@ packages:
       esbuild-windows-32: 0.13.14
       esbuild-windows-64: 0.13.14
       esbuild-windows-arm64: 0.13.14
-    dev: true
-
-  /esbuild/0.13.4:
-    resolution: {integrity: sha512-wMA5eUwpavTBiNl+It6j8OQuKVh69l6z4DKDLzoTIqC+gChnPpcmqdA8WNHptUHRnfyML+mKEQPlW7Mybj8gHg==}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      esbuild-android-arm64: 0.13.4
-      esbuild-darwin-64: 0.13.4
-      esbuild-darwin-arm64: 0.13.4
-      esbuild-freebsd-64: 0.13.4
-      esbuild-freebsd-arm64: 0.13.4
-      esbuild-linux-32: 0.13.4
-      esbuild-linux-64: 0.13.4
-      esbuild-linux-arm: 0.13.4
-      esbuild-linux-arm64: 0.13.4
-      esbuild-linux-mips64le: 0.13.4
-      esbuild-linux-ppc64le: 0.13.4
-      esbuild-openbsd-64: 0.13.4
-      esbuild-sunos-64: 0.13.4
-      esbuild-windows-32: 0.13.4
-      esbuild-windows-64: 0.13.4
-      esbuild-windows-arm64: 0.13.4
     dev: true
 
   /esbuild/0.14.5:
@@ -3623,7 +3306,7 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /eslint-config-standard/16.0.3_72c8a59d61ea280e4bd230741483b2d1:
+  /eslint-config-standard/16.0.3_4cecef3480376bac71ded249816d1e72:
     resolution: {integrity: sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==}
     peerDependencies:
       eslint: ^7.12.1
@@ -3634,7 +3317,7 @@ packages:
       eslint: 8.5.0
       eslint-plugin-import: 2.25.3_eslint@8.5.0
       eslint-plugin-node: 11.1.0_eslint@8.5.0
-      eslint-plugin-promise: 5.2.0_eslint@8.5.0
+      eslint-plugin-promise: 6.0.0_eslint@8.5.0
     dev: true
 
   /eslint-import-resolver-node/0.3.6:
@@ -3730,17 +3413,17 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-promise/5.2.0_eslint@8.5.0:
-    resolution: {integrity: sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /eslint-plugin-promise/6.0.0_eslint@8.5.0:
+    resolution: {integrity: sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^7.0.0
+      eslint: ^7.0.0 || ^8.0.0
     dependencies:
       eslint: 8.5.0
     dev: true
 
-  /eslint-plugin-react/7.27.1_eslint@8.5.0:
-    resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
+  /eslint-plugin-react/7.28.0_eslint@8.5.0:
+    resolution: {integrity: sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -3788,8 +3471,8 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-vue/8.1.1_eslint@8.5.0:
-    resolution: {integrity: sha512-rx64IrlhdfPya6u2V5ukOGiLCTgaCBdMSpczLVqyo8A0l+Vbo+lzvIfEUfAQ2auj+MF6y0TwxLorzdCIzHunnw==}
+  /eslint-plugin-vue/8.2.0_eslint@8.5.0:
+    resolution: {integrity: sha512-cLIdTuOAMXyHeQ4drYKcZfoyzdwdBpH279X8/N0DgmotEI9yFKb5O/cAgoie/CkQZCH/MOmh0xw/KEfS90zY2A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
@@ -3884,11 +3567,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-visitor-keys/3.0.0:
-    resolution: {integrity: sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
   /eslint-visitor-keys/3.1.0:
     resolution: {integrity: sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3952,15 +3630,6 @@ packages:
       import-meta-resolve: 1.1.1
     transitivePeerDependencies:
       - typescript
-    dev: true
-
-  /espree/9.0.0:
-    resolution: {integrity: sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      acorn: 8.5.0
-      acorn-jsx: 5.3.1_acorn@8.5.0
-      eslint-visitor-keys: 3.0.0
     dev: true
 
   /espree/9.2.0:
@@ -4397,6 +4066,7 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /has-symbols/1.0.2:
     resolution: {integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==}
@@ -4623,12 +4293,6 @@ packages:
   /is-callable/1.2.4:
     resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
     engines: {node: '>= 0.4'}
-    dev: true
-
-  /is-core-module/2.6.0:
-    resolution: {integrity: sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==}
-    dependencies:
-      has: 1.0.3
     dev: true
 
   /is-core-module/2.8.0:
@@ -4910,10 +4574,6 @@ packages:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
     dev: true
 
-  /json-schema/0.3.0:
-    resolution: {integrity: sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==}
-    dev: true
-
   /json-schema/0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
     dev: true
@@ -4945,10 +4605,10 @@ packages:
     resolution: {integrity: sha512-a3ZRus4qea0tSRCW2qvF/spFt7iCpdeJbiDjxbFZRZ87JCF8sI8hbxpVvUBVyZ3fLB/RQnTi+Y/yZbMlqt1BCg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.5.0
+      acorn: 8.6.0
       eslint-utils: 3.0.0_eslint@8.5.0
-      eslint-visitor-keys: 3.0.0
-      espree: 9.0.0
+      eslint-visitor-keys: 3.1.0
+      espree: 9.2.0
       semver: 7.3.5
     transitivePeerDependencies:
       - eslint
@@ -5043,6 +4703,13 @@ packages:
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
+    dev: true
+
+  /local-pkg/0.4.0:
+    resolution: {integrity: sha512-2XBWjO/v63JeR1HPzLJxdTVRQDB84Av2p2KtBA5ahvpyLUPubcAU6iXlAJrONcY7aSqgJhXxElAnKtnYsRolPQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 0.2.10
     dev: true
 
   /locate-path/2.0.0:
@@ -5140,8 +4807,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /markdown-it/12.2.0:
-    resolution: {integrity: sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==}
+  /markdown-it/12.3.0:
+    resolution: {integrity: sha512-T345UZZ6ejQWTjG6PSEHplzNy5m4kF6zvUpHVDv8Snl/pEU0OxIK0jGg8YLVNwJvT8E0YJC7/2UvssJDk/wQCQ==}
     hasBin: true
     dependencies:
       argparse: 2.0.1
@@ -5244,6 +4911,12 @@ packages:
 
   /minimist/1.2.5:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
+    dev: true
+
+  /mlly/0.2.10:
+    resolution: {integrity: sha512-xfyW6c2QBGArtctzNnTV5leOKX8nOMz2simeubtXofdsdSJFSNw+Ncvrs8kxcN3pBrQLXuYBHNFV6NgZ5Ryf4A==}
+    dependencies:
+      import-meta-resolve: 1.1.1
     dev: true
 
   /modify-values/1.0.1:
@@ -5641,11 +5314,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /pinia/2.0.3_typescript@4.4.4+vue@3.2.22:
-    resolution: {integrity: sha512-jNq+eVCAbFQS/uOiqskSRsKsFzLcQpgegcpjI8eAzU3QOwmsdLLHZBE1dvy802jecRC3FPPJSlj1MISF/sRV2w==}
+  /pinia/2.0.9_typescript@4.5.4+vue@3.2.26:
+    resolution: {integrity: sha512-iuYdxLJKQ07YPyOHYH05wNG9eKWqkP/4y4GE8+RqEYtz5fwHgPA5kr6zQbg/DoEJGnR2XCm1w1vdt6ppzL9ATg==}
     peerDependencies:
-      '@vue/composition-api': ^1.3.3
-      typescript: ^4.4.4
+      '@vue/composition-api': ^1.4.0
+      typescript: '>=4.4.4'
       vue: ^2.6.14 || ^3.2.0
     peerDependenciesMeta:
       '@vue/composition-api':
@@ -5653,10 +5326,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@vue/devtools-api': 6.0.0-beta.20.1
-      typescript: 4.4.4
-      vue: 3.2.22
-      vue-demi: 0.11.3_vue@3.2.22
+      '@vue/devtools-api': 6.0.0-beta.21.1
+      typescript: 4.5.4
+      vue: 3.2.26
+      vue-demi: 0.11.3_vue@3.2.26
     dev: false
 
   /pinkie-promise/2.0.1:
@@ -5993,7 +5666,7 @@ packages:
   /resolve/1.20.0:
     resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==}
     dependencies:
-      is-core-module: 2.6.0
+      is-core-module: 2.8.0
       path-parse: 1.0.7
     dev: true
 
@@ -6016,48 +5689,28 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /rollup-plugin-terser/7.0.2_rollup@2.60.0:
+  /rollup-plugin-terser/7.0.2_rollup@2.62.0:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
       '@babel/code-frame': 7.14.5
       jest-worker: 26.6.2
-      rollup: 2.60.0
+      rollup: 2.62.0
       serialize-javascript: 4.0.0
       terser: 5.7.1
-    dev: true
-
-  /rollup-plugin-terser/7.0.2_rollup@2.61.1:
-    resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
-    peerDependencies:
-      rollup: ^2.0.0
-    dependencies:
-      '@babel/code-frame': 7.14.5
-      jest-worker: 26.6.2
-      rollup: 2.61.1
-      serialize-javascript: 4.0.0
-      terser: 5.7.1
-    dev: true
-
-  /rollup/2.58.0:
-    resolution: {integrity: sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /rollup/2.60.0:
-    resolution: {integrity: sha512-cHdv9GWd58v58rdseC8e8XIaPUo8a9cgZpnCMMDGZFDZKEODOiPPEQFXLriWr/TjXzhPPmG5bkAztPsOARIcGQ==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /rollup/2.61.1:
     resolution: {integrity: sha512-BbTXlEvB8d+XFbK/7E5doIcRtxWPRiqr0eb5vQ0+2paMM04Ye4PZY5nHOQef2ix24l/L0SpLd5hwcH15QHPdvA==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /rollup/2.62.0:
+    resolution: {integrity: sha512-cJEQq2gwB0GWMD3rYImefQTSjrPYaC6s4J9pYqnstVLJ1CHa/aZNVkD4Epuvg4iLeMA4KRiq7UM7awKK6j7jcw==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -6284,15 +5937,6 @@ packages:
     engines: {node: '>=0.6.19'}
     dev: true
 
-  /string-width/4.2.2:
-    resolution: {integrity: sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==}
-    engines: {node: '>=8'}
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-    dev: true
-
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -6352,12 +5996,6 @@ packages:
   /stringify-package/1.0.1:
     resolution: {integrity: sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==}
     dev: true
-
-  /strip-ansi/6.0.0:
-    resolution: {integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==}
-    engines: {node: '>=8'}
-    dependencies:
-      ansi-regex: 5.0.0
 
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -6437,6 +6075,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -6577,11 +6216,11 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsup/5.11.6_typescript@4.5.4:
-    resolution: {integrity: sha512-mKhLdQ1N2KMV31dsX4MLO5l4FOORf2+FvyAOott3ZgiSnKisZiOoCXwxPc97iPqIk5aouyQBTaZcjXKJV+C4pg==}
+  /tsup/5.11.9_typescript@4.5.4:
+    resolution: {integrity: sha512-APFcd9qKblMVO35O5OyIcfa4lwBrVNinwtifUojO78I6j0aDhS4fQ06gq6vF1b/+Z83pYDWNb0R2fmO9PX3IVQ==}
     hasBin: true
     peerDependencies:
-      typescript: ^4.2.3
+      typescript: ^4.1.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6589,14 +6228,14 @@ packages:
       bundle-require: 2.1.8_esbuild@0.14.5
       cac: 6.7.12
       chokidar: 3.5.1
-      debug: 4.3.2
+      debug: 4.3.3
       esbuild: 0.14.5
       execa: 5.0.0
       globby: 11.0.4
       joycon: 3.0.1
       postcss-load-config: 3.0.1
       resolve-from: 5.0.0
-      rollup: 2.61.1
+      rollup: 2.62.0
       source-map: 0.7.3
       sucrase: 3.20.3
       tree-kill: 1.2.2
@@ -6661,12 +6300,6 @@ packages:
 
   /typedarray/0.0.6:
     resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
-    dev: true
-
-  /typescript/4.4.4:
-    resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
     dev: true
 
   /typescript/4.5.4:
@@ -6776,7 +6409,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-plugin-components/0.13.3_vite@2.6.14:
+  /vite-plugin-components/0.13.3_vite@2.7.10:
     resolution: {integrity: sha512-6vLWPrEqFSW7REYvux/WVwxsytg/DcstVhdgAT806cZi/KGiQgB8dyFnLkrkFawxUQruuGkLWfS99Z/64mMC0w==}
     deprecated: renamed to `unplugin-vue-components`, see https://github.com/antfu/unplugin-vue-components/releases/tag/v0.14.0
     peerDependencies:
@@ -6786,25 +6419,26 @@ packages:
       fast-glob: 3.2.7
       magic-string: 0.25.7
       minimatch: 3.0.4
-      vite: 2.6.14
+      vite: 2.7.10
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-md/0.11.4_vite@2.6.14:
-    resolution: {integrity: sha512-t24rdVSB72k8xeLcuMhwl0ku5hvsQkt7NfVNG1LEaTOykbXTgwcGD8OUTmryOsGGhCw2DuCZJvTs+qK07J7Gug==}
+  /vite-plugin-md/0.11.7_vite@2.7.10:
+    resolution: {integrity: sha512-RRdmadGpCxJLeeMXy93SWFz6kzh35NO7QjgHkvggC4BxoDXkVwNJRjSKgMvINWnJVPnkhiAs0o6k1QepazIwxw==}
     peerDependencies:
       vite: ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 4.1.1
+      '@antfu/utils': 0.3.0
+      '@rollup/pluginutils': 4.1.2
       '@types/markdown-it': 12.2.3
       gray-matter: 4.0.3
-      markdown-it: 12.2.0
-      vite: 2.6.14
+      markdown-it: 12.3.0
+      vite: 2.7.10
     dev: true
 
-  /vite-plugin-pages/0.18.2_vite@2.6.14:
-    resolution: {integrity: sha512-Z6ylvMKYSiCngtSpWw9pHN4UzjMQvOG7f0RtLMDKm1LrO5iye7V8BS8Rfdvrl9Nz+D2W+i0pi98+vOL5VsmTvQ==}
+  /vite-plugin-pages/0.19.8_vite@2.7.10:
+    resolution: {integrity: sha512-KwUYl5zFzLKc4eCEDp4xvbH5plqmkWN5i1JYgLIksCp5NK3FiXEaWmtQ8hSKgFo4pzV9BJ8hwWf0xYxEQzAbmQ==}
     peerDependencies:
       '@vue/compiler-sfc': '>=3'
       vite: '>=2'
@@ -6812,18 +6446,18 @@ packages:
       '@vue/compiler-sfc':
         optional: true
     dependencies:
-      '@antfu/utils': 0.3.0
-      debug: 4.3.2
+      debug: 4.3.3
       deep-equal: 2.0.5
       fast-glob: 3.2.7
       json5: 2.2.0
-      vite: 2.6.14
-      yaml: 2.0.0-8
+      local-pkg: 0.4.0
+      vite: 2.7.10
+      yaml: 2.0.0-9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.11.12_vite@2.7.3:
+  /vite-plugin-pwa/0.11.12_vite@2.7.10:
     resolution: {integrity: sha512-XqFmA4y9C4RBb5osSsa26GVwOSwbzf2GNVcT5+06KYYdguqLpuI9FW7iV/akZqg0OUNUpH4tHfme8SnHA4PIXA==}
     peerDependencies:
       vite: ^2.0.0
@@ -6831,8 +6465,8 @@ packages:
       debug: 4.3.3
       fast-glob: 3.2.7
       pretty-bytes: 5.6.0
-      rollup: 2.61.1
-      vite: 2.7.3
+      rollup: 2.62.0
+      vite: 2.7.10
       workbox-build: 6.4.2
       workbox-window: 6.4.2
     transitivePeerDependencies:
@@ -6840,50 +6474,8 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.11.5_vite@2.6.14:
-    resolution: {integrity: sha512-qn79L7008ZMn9GS0ClxypOBRA3Ft8/a8saIQ03SC2R1QndbZVW+YQVHTlFno33Wp6fu5UJacoHWuZYCuKZKaOA==}
-    peerDependencies:
-      vite: ^2.0.0
-    dependencies:
-      chalk: 4.1.2
-      debug: 4.3.2
-      fast-glob: 3.2.7
-      pretty-bytes: 5.6.0
-      rollup: 2.60.0
-      vite: 2.6.14
-      workbox-build: 6.4.1
-      workbox-window: 6.4.1
-    transitivePeerDependencies:
-      - '@types/babel__core'
-      - supports-color
-    dev: true
-
-  /vite/2.6.14:
-    resolution: {integrity: sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==}
-    engines: {node: '>=12.2.0'}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-    dependencies:
-      esbuild: 0.13.4
-      postcss: 8.3.9
-      resolve: 1.20.0
-      rollup: 2.58.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite/2.7.3:
-    resolution: {integrity: sha512-GAY1P+9fLJOju1SRm8+hykVnEXog+E+KXuqqyMBQDriKCUIKzWnPn142yNNhSdf/ixYGYdUa5ce3A8WaEajzGw==}
+  /vite/2.7.10:
+    resolution: {integrity: sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -6906,7 +6498,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vue-demi/0.11.3_vue@3.2.22:
+  /vue-demi/0.11.3_vue@3.2.26:
     resolution: {integrity: sha512-DpM0TTMpclRZDV6AIacgg837zrim/C9Zn+2ztXBs9hsESJN9vC83ztjTe4KC4HgJuVle8YUjPp7HTwWtwOHfmg==}
     engines: {node: '>=12'}
     hasBin: true
@@ -6918,7 +6510,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.2.22
+      vue: 3.2.26
     dev: false
 
   /vue-eslint-parser/8.0.1_eslint@8.5.0:
@@ -6930,22 +6522,13 @@ packages:
       debug: 4.3.3
       eslint: 8.5.0
       eslint-scope: 6.0.0
-      eslint-visitor-keys: 3.0.0
-      espree: 9.0.0
+      eslint-visitor-keys: 3.1.0
+      espree: 9.2.0
       esquery: 1.4.0
       lodash: 4.17.21
       semver: 7.3.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /vue-router/4.0.12_vue@3.2.22:
-    resolution: {integrity: sha512-CPXvfqe+mZLB1kBWssssTiWg4EQERyqJZes7USiqfW9B5N2x+nHlnsM1D3b5CaJ6qgCvMmYJnz+G0iWjNCvXrg==}
-    peerDependencies:
-      vue: ^3.0.0
-    dependencies:
-      '@vue/devtools-api': 6.0.0-beta.19
-      vue: 3.2.22
     dev: true
 
   /vue-router/4.0.12_vue@3.2.26:
@@ -6957,16 +6540,6 @@ packages:
       vue: 3.2.26
     dev: true
 
-  /vue/3.2.22:
-    resolution: {integrity: sha512-KD5nZpXVZquOC6926Xnp3zOvswrUyO9Rya7ZUoxWFQEjFDW4iACtwzubRB4Um2Om9kj6CaJOqAVRDSFlqLpdgw==}
-    dependencies:
-      '@vue/compiler-dom': 3.2.22
-      '@vue/compiler-sfc': 3.2.22
-      '@vue/runtime-dom': 3.2.22
-      '@vue/server-renderer': 3.2.22_vue@3.2.22
-      '@vue/shared': 3.2.22
-    dev: false
-
   /vue/3.2.26:
     resolution: {integrity: sha512-KD4lULmskL5cCsEkfhERVRIOEDrfEL9CwAsLYpzptOGjaGFNWo3BQ9g8MAb7RaIO71rmVOziZ/uEN/rHwcUIhg==}
     dependencies:
@@ -6975,7 +6548,6 @@ packages:
       '@vue/runtime-dom': 3.2.26
       '@vue/server-renderer': 3.2.26_vue@3.2.26
       '@vue/shared': 3.2.26
-    dev: true
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
@@ -7075,13 +6647,6 @@ packages:
     resolution: {integrity: sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=}
     dev: true
 
-  /workbox-background-sync/6.4.1:
-    resolution: {integrity: sha512-GiDklRhDF/oJ+WJhb6jO00wA+fjOZlY4SomqpumXP6OXp1WodmKu7xv75hpum0Kx4Fh3MZrj+9Ae+dIYlq21dA==}
-    dependencies:
-      idb: 6.1.5
-      workbox-core: 6.4.1
-    dev: true
-
   /workbox-background-sync/6.4.2:
     resolution: {integrity: sha512-P7c8uG5X2k+DMICH9xeSA9eUlCOjHHYoB42Rq+RtUpuwBxUOflAXR1zdsMWj81LopE4gjKXlTw7BFd1BDAHo7g==}
     dependencies:
@@ -7089,63 +6654,10 @@ packages:
       workbox-core: 6.4.2
     dev: true
 
-  /workbox-broadcast-update/6.4.1:
-    resolution: {integrity: sha512-oz1WAEppIatucgIc49zXPsyQG6004eoKsyiJVGDyN94LIFpUDfGa+cykN32X0PaqOC9bdlj+4EjVBi0OuwkIHA==}
-    dependencies:
-      workbox-core: 6.4.1
-    dev: true
-
   /workbox-broadcast-update/6.4.2:
     resolution: {integrity: sha512-qnBwQyE0+PWFFc/n4ISXINE49m44gbEreJUYt2ldGH3+CNrLmJ1egJOOyUqqu9R4Eb7QrXcmB34ClXG7S37LbA==}
     dependencies:
       workbox-core: 6.4.2
-    dev: true
-
-  /workbox-build/6.4.1:
-    resolution: {integrity: sha512-cvH74tEO8SrziFrCntZ/35B0uaMZFKG+gnk3vZmKLSUTab/6MlhL+UwYXf1sMV5SD/W/v7pnFKZbdAOAg5Ne2w==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@apideck/better-ajv-errors': 0.2.7_ajv@8.6.2
-      '@babel/core': 7.14.8
-      '@babel/preset-env': 7.14.8_@babel+core@7.14.8
-      '@babel/runtime': 7.14.8
-      '@rollup/plugin-babel': 5.3.0_@babel+core@7.14.8+rollup@2.60.0
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.60.0
-      '@rollup/plugin-replace': 2.4.2_rollup@2.60.0
-      '@surma/rollup-plugin-off-main-thread': 2.2.3
-      ajv: 8.6.2
-      common-tags: 1.8.0
-      fast-json-stable-stringify: 2.1.0
-      fs-extra: 9.1.0
-      glob: 7.1.7
-      lodash: 4.17.21
-      pretty-bytes: 5.6.0
-      rollup: 2.60.0
-      rollup-plugin-terser: 7.0.2_rollup@2.60.0
-      source-map: 0.8.0-beta.0
-      source-map-url: 0.4.1
-      stringify-object: 3.3.0
-      strip-comments: 2.0.1
-      tempy: 0.6.0
-      upath: 1.2.0
-      workbox-background-sync: 6.4.1
-      workbox-broadcast-update: 6.4.1
-      workbox-cacheable-response: 6.4.1
-      workbox-core: 6.4.1
-      workbox-expiration: 6.4.1
-      workbox-google-analytics: 6.4.1
-      workbox-navigation-preload: 6.4.1
-      workbox-precaching: 6.4.1
-      workbox-range-requests: 6.4.1
-      workbox-recipes: 6.4.1
-      workbox-routing: 6.4.1
-      workbox-strategies: 6.4.1
-      workbox-streams: 6.4.1
-      workbox-sw: 6.4.1
-      workbox-window: 6.4.1
-    transitivePeerDependencies:
-      - '@types/babel__core'
-      - supports-color
     dev: true
 
   /workbox-build/6.4.2:
@@ -7156,9 +6668,9 @@ packages:
       '@babel/core': 7.14.8
       '@babel/preset-env': 7.14.8_@babel+core@7.14.8
       '@babel/runtime': 7.14.8
-      '@rollup/plugin-babel': 5.3.0_@babel+core@7.14.8+rollup@2.61.1
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.61.1
-      '@rollup/plugin-replace': 2.4.2_rollup@2.61.1
+      '@rollup/plugin-babel': 5.3.0_@babel+core@7.14.8+rollup@2.62.0
+      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.62.0
+      '@rollup/plugin-replace': 2.4.2_rollup@2.62.0
       '@surma/rollup-plugin-off-main-thread': 2.2.3
       ajv: 8.6.2
       common-tags: 1.8.0
@@ -7167,8 +6679,8 @@ packages:
       glob: 7.1.7
       lodash: 4.17.21
       pretty-bytes: 5.6.0
-      rollup: 2.61.1
-      rollup-plugin-terser: 7.0.2_rollup@2.61.1
+      rollup: 2.62.0
+      rollup-plugin-terser: 7.0.2_rollup@2.62.0
       source-map: 0.8.0-beta.0
       source-map-url: 0.4.1
       stringify-object: 3.3.0
@@ -7195,31 +6707,14 @@ packages:
       - supports-color
     dev: true
 
-  /workbox-cacheable-response/6.4.1:
-    resolution: {integrity: sha512-omXplP3miJhQwx+jfFnqO9xWgNc8CLG6EWRvTyc8R81cA/4zhqh87yj9UVH+fGUmuIXOUBPAuulSazXUsvKFWg==}
-    dependencies:
-      workbox-core: 6.4.1
-    dev: true
-
   /workbox-cacheable-response/6.4.2:
     resolution: {integrity: sha512-9FE1W/cKffk1AJzImxgEN0ceWpyz1tqNjZVtA3/LAvYL3AC5SbIkhc7ZCO82WmO9IjTfu8Vut2X/C7ViMSF7TA==}
     dependencies:
       workbox-core: 6.4.2
     dev: true
 
-  /workbox-core/6.4.1:
-    resolution: {integrity: sha512-5hosqpSK+48jHlj+5EHN5dtH1Ade4fqTe4+xX3U9wWK1SDaXEqXpVxdHuBqYfg75UE1PUINA0rhMZWTqeGoLFg==}
-    dev: true
-
   /workbox-core/6.4.2:
     resolution: {integrity: sha512-1U6cdEYPcajRXiboSlpJx6U7TvhIKbxRRerfepAJu2hniKwJ3DHILjpU/zx3yvzSBCWcNJDoFalf7Vgd7ey/rw==}
-    dev: true
-
-  /workbox-expiration/6.4.1:
-    resolution: {integrity: sha512-N912AGhi95vhf2vebE3wPhnGjnR+t5W4yALDY7Pl6bcuhySNbwkkp2RjQcBB+dxrdiX2rOvavvdcf/q1LSnEyg==}
-    dependencies:
-      idb: 6.1.5
-      workbox-core: 6.4.1
     dev: true
 
   /workbox-expiration/6.4.2:
@@ -7227,15 +6722,6 @@ packages:
     dependencies:
       idb: 6.1.5
       workbox-core: 6.4.2
-    dev: true
-
-  /workbox-google-analytics/6.4.1:
-    resolution: {integrity: sha512-L1JQISg1CxMAlqw3HXpWB2gRYsmJ9F9OgC2/UNAZLyOJTFk1faZziPS4eXe+UaHevZ+Ma66Z2zfYxPUTr5znjQ==}
-    dependencies:
-      workbox-background-sync: 6.4.1
-      workbox-core: 6.4.1
-      workbox-routing: 6.4.1
-      workbox-strategies: 6.4.1
     dev: true
 
   /workbox-google-analytics/6.4.2:
@@ -7247,24 +6733,10 @@ packages:
       workbox-strategies: 6.4.2
     dev: true
 
-  /workbox-navigation-preload/6.4.1:
-    resolution: {integrity: sha512-npgZYoeaE+teQvpWqZLgJDJ6I3qxwqAfnSIa8yrNQ2sLR1A88uWGGsiRzfUsIdKjVCLPQVZ+clwb6XU1vyW9Lw==}
-    dependencies:
-      workbox-core: 6.4.1
-    dev: true
-
   /workbox-navigation-preload/6.4.2:
     resolution: {integrity: sha512-viyejlCtlKsbJCBHwhSBbWc57MwPXvUrc8P7d+87AxBGPU+JuWkT6nvBANgVgFz6FUhCvRC8aYt+B1helo166g==}
     dependencies:
       workbox-core: 6.4.2
-    dev: true
-
-  /workbox-precaching/6.4.1:
-    resolution: {integrity: sha512-Sq8d+/wfcXFjwuVwKe2VxD4QddRBgkO6pJVgpHbk5WFynR8dc8Zj3BlJ38e4nMlRuBZ8996TIgAmk/U6Rr5YHQ==}
-    dependencies:
-      workbox-core: 6.4.1
-      workbox-routing: 6.4.1
-      workbox-strategies: 6.4.1
     dev: true
 
   /workbox-precaching/6.4.2:
@@ -7275,27 +6747,10 @@ packages:
       workbox-strategies: 6.4.2
     dev: true
 
-  /workbox-range-requests/6.4.1:
-    resolution: {integrity: sha512-X/asYHeuWIKg5Tk+dfmiEOo9hlkQ1K737dnENj8zL97kZDdcfokPT5CuXgM2xqX7NMoahONq1Eo2UoFfJNjZzg==}
-    dependencies:
-      workbox-core: 6.4.1
-    dev: true
-
   /workbox-range-requests/6.4.2:
     resolution: {integrity: sha512-SowF3z69hr3Po/w7+xarWfzxJX/3Fo0uSG72Zg4g5FWWnHpq2zPvgbWerBZIa81zpJVUdYpMa3akJJsv+LaO1Q==}
     dependencies:
       workbox-core: 6.4.2
-    dev: true
-
-  /workbox-recipes/6.4.1:
-    resolution: {integrity: sha512-Yu9tLmgD25NorZPO3FHJUii/Y2ghrx2jD2QKMaWBBplshw1MFokqlmr3Dz3O6NI8jBBUnK5Dtbl0+SCwVGSCqg==}
-    dependencies:
-      workbox-cacheable-response: 6.4.1
-      workbox-core: 6.4.1
-      workbox-expiration: 6.4.1
-      workbox-precaching: 6.4.1
-      workbox-routing: 6.4.1
-      workbox-strategies: 6.4.1
     dev: true
 
   /workbox-recipes/6.4.2:
@@ -7309,35 +6764,16 @@ packages:
       workbox-strategies: 6.4.2
     dev: true
 
-  /workbox-routing/6.4.1:
-    resolution: {integrity: sha512-FIy27mwM3WdDASOTMX10OZ8q3Un47ULeDtDrDAKfWYIP/oTF2xoA1/HtXpOjBlyg5VP/poPX5GDojXHXAXpfzQ==}
-    dependencies:
-      workbox-core: 6.4.1
-    dev: true
-
   /workbox-routing/6.4.2:
     resolution: {integrity: sha512-0ss/n9PAcHjTy4Ad7l2puuod4WtsnRYu9BrmHcu6Dk4PgWeJo1t5VnGufPxNtcuyPGQ3OdnMdlmhMJ57sSrrSw==}
     dependencies:
       workbox-core: 6.4.2
     dev: true
 
-  /workbox-strategies/6.4.1:
-    resolution: {integrity: sha512-2UQ+7Siy4Z5QG2LebbVhDLmPG3M7bVo/tZqN4LNUGXS6fDlpbTTK6A3Hu0W8gCVwIX0tSg7U3mVhDntH4qt3Dg==}
-    dependencies:
-      workbox-core: 6.4.1
-    dev: true
-
   /workbox-strategies/6.4.2:
     resolution: {integrity: sha512-YXh9E9dZGEO1EiPC3jPe2CbztO5WT8Ruj8wiYZM56XqEJp5YlGTtqRjghV+JovWOqkWdR+amJpV31KPWQUvn1Q==}
     dependencies:
       workbox-core: 6.4.2
-    dev: true
-
-  /workbox-streams/6.4.1:
-    resolution: {integrity: sha512-0t3QKBml3Qi37JniDfEn0FfN4JRgMK6sEcjGxvmMGwlHAyKukZr0Gj58ax1o1KYGGJr72RDBK+YXI9Sk9cKifw==}
-    dependencies:
-      workbox-core: 6.4.1
-      workbox-routing: 6.4.1
     dev: true
 
   /workbox-streams/6.4.2:
@@ -7347,19 +6783,8 @@ packages:
       workbox-routing: 6.4.2
     dev: true
 
-  /workbox-sw/6.4.1:
-    resolution: {integrity: sha512-IJNYcNbjugMB9v+Yx7uswohjOaYoimw5dI0Gcaj2zrJHKjV0bom+BPRCdijmttN/3uVbX57jhNe8SMzWMj7fHw==}
-    dev: true
-
   /workbox-sw/6.4.2:
     resolution: {integrity: sha512-A2qdu9TLktfIM5NE/8+yYwfWu+JgDaCkbo5ikrky2c7r9v2X6DcJ+zSLphNHHLwM/0eVk5XVf1mC5HGhYpMhhg==}
-    dev: true
-
-  /workbox-window/6.4.1:
-    resolution: {integrity: sha512-v5G1U+NN0sHErvE9fzHRA75FrfRFj/0dihFnvno5yqHZZIb9G4U2AarodSDRBC3t6CsnLO68l1Bj1gsHqsM9Qw==}
-    dependencies:
-      '@types/trusted-types': 2.0.2
-      workbox-core: 6.4.1
     dev: true
 
   /workbox-window/6.4.2:
@@ -7375,7 +6800,7 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
-      strip-ansi: 6.0.0
+      strip-ansi: 6.0.1
 
   /wrappy/1.0.2:
     resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
@@ -7420,7 +6845,7 @@ packages:
     resolution: {integrity: sha512-nJeyLA3YHAzhBTZbRAbu3W6xrSCucyxExmA+ZDtEdUFpGllxAZpto2Zxo2IG0r0eiuEiBM4e+wiAdxTziTq94g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      eslint-visitor-keys: 3.0.0
+      eslint-visitor-keys: 3.1.0
       lodash: 4.17.21
       yaml: 1.10.2
     dev: true
@@ -7430,14 +6855,9 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /yaml/2.0.0-8:
-    resolution: {integrity: sha512-QaYgJZMfWD6fKN/EYMk6w1oLWPCr1xj9QaPSZW5qkDb3y8nGCXhy2Ono+AF4F+CSL/vGcqswcAT0BaS//pgD2A==}
+  /yaml/2.0.0-9:
+    resolution: {integrity: sha512-Bf2KowHjyVkIIiGMt7+fbhmlvKOaE8DWuD07bnL4+FQ9sPmEl/5IzGpBpoxPqOaHuyasBjJhyXDcISpJWfhCGw==}
     engines: {node: '>= 12'}
-    dev: true
-
-  /yargs-parser/20.2.7:
-    resolution: {integrity: sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==}
-    engines: {node: '>=10'}
     dev: true
 
   /yargs-parser/20.2.9:
@@ -7458,13 +6878,13 @@ packages:
       escalade: 3.1.1
       get-caller-file: 2.0.5
       require-directory: 2.1.1
-      string-width: 4.2.2
+      string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 20.2.7
+      yargs-parser: 20.2.9
     dev: true
 
-  /yargs/17.3.0:
-    resolution: {integrity: sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==}
+  /yargs/17.3.1:
+    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
     engines: {node: '>=12'}
     dependencies:
       cliui: 7.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.8.1
       '@vueuse/head': ^0.7.4
       bumpp: ^7.1.1
-      chalk: ^5.0.0
       critters: ^0.0.15
       eslint: ^8.5.0
       esno: ^0.13.0
       fs-extra: ^10.0.0
       html-minifier: ^4.0.0
       jsdom: ^19.0.0
+      kolorist: ^1.5.1
       prettier: ^2.5.1
       rollup: ^2.62.0
       standard-version: ^9.3.2
@@ -31,10 +31,10 @@ importers:
       vue-router: ^4.0.12
       yargs: ^17.3.1
     dependencies:
-      chalk: 5.0.0
       fs-extra: 10.0.0
       html-minifier: 4.0.0
       jsdom: 19.0.0
+      kolorist: 1.5.1
       prettier: 2.5.1
       yargs: 17.3.1
     devDependencies:
@@ -2273,11 +2273,6 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
     dev: true
-
-  /chalk/5.0.0:
-    resolution: {integrity: sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: false
 
   /chokidar/3.5.1:
     resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
@@ -4652,6 +4647,10 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
     dev: true
+
+  /kolorist/1.5.1:
+    resolution: {integrity: sha512-lxpCM3HTvquGxKGzHeknB/sUjuVoUElLlfYnXZT73K8geR9jQbroGlSCFBax9/0mpGoD3kzcMLnOlGQPJJNyqQ==}
+    dev: false
 
   /leven/3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -9,7 +9,7 @@ import type { SSRContext } from 'vue/server-renderer'
 import { JSDOM } from 'jsdom'
 import type { RollupOutput } from 'rollup'
 import type { VitePluginPWAAPI } from 'vite-plugin-pwa'
-import type { ViteSSGContext, ViteSSGOptions } from '../client'
+import type { ViteSSGContext, ViteSSGOptions } from '../types'
 import { renderPreloadLinks } from './preload-links'
 import { buildLog, getSize, routesToPaths } from './utils'
 import { getCritters } from './critical'
@@ -194,7 +194,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
 
   // when `vite-plugin-pwa` is presented, use it to regenerate SW after rendering
   const pwaPlugin: VitePluginPWAAPI = config.plugins.find(i => i.name === 'vite-plugin-pwa')?.api
-  if (pwaPlugin?.generateSW) {
+  if (pwaPlugin && !pwaPlugin.disabled && pwaPlugin.generateSW) {
     buildLog('Regenerate PWA...')
     await pwaPlugin.generateSW()
   }

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -190,7 +190,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
     }),
   )
 
-  // await fs.remove(ssgOut)
+  await fs.remove(ssgOut)
 
   // when `vite-plugin-pwa` is presented, use it to regenerate SW after rendering
   const pwaPlugin: VitePluginPWAAPI = config.plugins.find(i => i.name === 'vite-plugin-pwa')?.api

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-expressions */
-import chalk from 'chalk'
+import { bold, gray, red, reset, underline } from 'kolorist'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { build } from './build'
@@ -24,8 +24,8 @@ yargs(hideBin(process.argv))
     },
   )
   .fail((msg, err, yargs) => {
-    console.error(`\n${chalk.gray('[vite-ssg]')} ${chalk.red.bold('An internal error occurred.')}`)
-    console.error(`${chalk.gray('[vite-ssg]')} ${chalk.white(`Please report an issue, if none already exists: ${chalk.underline('https://github.com/antfu/vite-ssg/issues')}`)}`)
+    console.error(`\n${gray('[vite-ssg]')} ${bold(red('An internal error occurred.'))}`)
+    console.error(`${gray('[vite-ssg]')} ${reset(`Please report an issue, if none already exists: ${underline('https://github.com/antfu/vite-ssg/issues')}`)}`)
     yargs.exit(1, err)
   })
   .showHelpOnFail(false)

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -1,9 +1,9 @@
-import chalk from 'chalk'
+import { blue, gray, yellow } from 'kolorist'
 import type { RouteRecordRaw } from 'vue-router'
 
 export function buildLog(text: string, count?: number) {
   // eslint-disable-next-line no-console
-  console.log(`\n${chalk.gray('[vite-ssg]')} ${chalk.yellow(text)}${count ? chalk.blue(` (${count})`) : ''}`)
+  console.log(`\n${gray('[vite-ssg]')} ${yellow(text)}${count ? blue(` (${count})`) : ''}`)
 }
 
 export function getSize(str: string) {


### PR DESCRIPTION
This PR includes:
- use `unbuild` instead `tsup`
- updated `package.json` to include types and change `js` extension with `cjs` extension; added also `sideEffect: false`.
- modified `single-page` and `multiple-pages-with-store` examples: we need to enable `cjs` format since it seems `vue-demi` is not `esm` compliant (the error comes from `pinia.mjs`, see below).
- modified `vite-ssg` binary to load `cjs` (via `require`) or `esm` (via `dynamic import`) module checking for `__dirname`.
- included regenerate `pwa`  if `disabled api`  option is false (option included on `v0.11.12`).
- using `kolorist` instead `chalk`
- updated all dependencies  to major

Error when building `single-page` with `esm`:

```shell
[vite-ssg] An internal error occurred.
[vite-ssg] Please report an issue, if none already exists: https://github.com/antfu/vite-ssg/issues
file:///F:/work/projects/quini/GitHub/antfu/vite-ssg-node16/node_modules/.pnpm/pinia@2.0.9_typescript@4.5.4+vue@3.2.26/node_modules/pinia/dist/pinia.mjs:6
import { getCurrentInstance, inject, toRaw, watch, unref, markRaw, effectScope, ref, isVue2, isRef, isReactive, set, onUnmounted, reactive, toRef, del, nextTick, computed, toRefs } from 'vue-demi';
                                                                                                                                                                  ^^^^^^^^
SyntaxError: Named export 'computed' not found. The requested module 'vue-demi' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'vue-demi';
const { getCurrentInstance, inject, toRaw, watch, unref, markRaw, effectScope, ref, isVue2, isRef, isReactive, set, onUnmounted, reactive, toRef, del, nextTick, computed, toRefs } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:181:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:437:15)
    at async build (F:\work\projects\quini\GitHub\antfu\vite-ssg-node16\dist\node\cli.cjs:179:44)
    at async Object.handler (F:\work\projects\quini\GitHub\antfu\vite-ssg-node16\dist\node\cli.cjs:291:3)

```

