### PR TITLE
feat: throw if <div id="app"></div> is absent

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -242,7 +242,7 @@ function renderHTML({ indexHTML, appHTML, initialState }: { indexHTML: string; a
     ? `\n<script>window.__INITIAL_STATE__=${initialState}</script>`
     : ''
   if (!indexHTML.includes('<div id="app"></div>')) {
-    throw new Error(`Could not find '<div id="app"></div>' to replace it with server-side rendered HTML!`)
+    throw new Error(`Could not find '<div id="app"></div>' to replace it with server-side rendered HTML`)
   }
   return indexHTML
     .replace(

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -241,6 +241,9 @@ function renderHTML({ indexHTML, appHTML, initialState }: { indexHTML: string; a
   const stateScript = initialState
     ? `\n<script>window.__INITIAL_STATE__=${initialState}</script>`
     : ''
+  if (!indexHTML.includes('<div id="app"></div>')) {
+    throw new Error(`Could not find '<div id="app"></div>' to replace it with server-side rendered HTML!`)
+  }
   return indexHTML
     .replace(
       '<div id="app"></div>',


### PR DESCRIPTION
If the `index.html` is modified in the part of `<div id="app"></div>`, `vite-ssg` will not modify the HTML read from `index.html` before outputting it. All server-side rendering was for nothing in this case.

In #118 examples were discussed, where this actually happened.

This PR does not solve the issue by providing a robust way of identifying *the div with the id "app"*, but instead at least notifies the user what went wrong.

In a later PR this could be fixed properly.
My proposal would be to parse and tokenize the HTML with an html parser and get the position of the div in the file by working with the index.html's abstract syntax tree **if `<div id="app"></div>` cannot be found as string**. But that's a topic for another PR.