### PR TITLE
feat: finds id="app" using parser as fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "fs-extra": "^10.0.0",
     "html-minifier": "^4.0.0",
+    "html5parser": "^2.0.2",
     "jsdom": "^19.0.0",
     "kolorist": "^1.5.1",
     "prettier": "^2.5.1",

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -152,7 +152,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
         const appHTML = await renderToString(app, ctx)
         await triggerOnSSRAppRendered?.(route, appHTML, appCtx)
         // need to resolve assets so render content first
-        const renderedHTML = renderHTML({ indexHTML: transformedIndexHTML, appHTML, initialState: transformState(initialState) })
+        const renderedHTML = await renderHTML({ indexHTML: transformedIndexHTML, appHTML, initialState: transformState(initialState) })
 
         // create jsdom from renderedHTML
         const jsdom = new JSDOM(renderedHTML)
@@ -237,18 +237,43 @@ function rewriteScripts(indexHTML: string, mode?: string) {
   return indexHTML.replace(/<script type="module" /g, `<script type="module" ${mode} `)
 }
 
-function renderHTML({ indexHTML, appHTML, initialState }: { indexHTML: string; appHTML: string; initialState: any }) {
+async function renderHTML({ indexHTML, appHTML, initialState }: { indexHTML: string; appHTML: string; initialState: any }) {
   const stateScript = initialState
     ? `\n<script>window.__INITIAL_STATE__=${initialState}</script>`
     : ''
-  if (!indexHTML.includes('<div id="app"></div>')) {
-    throw new Error(`Could not find '<div id="app"></div>' to replace it with server-side rendered HTML`)
+  if (indexHTML.includes('<div id="app"></div>')) {
+    return indexHTML
+      .replace(
+        '<div id="app"></div>',
+        `<div id="app" data-server-rendered="true">${appHTML}</div>${stateScript}`,
+      )
   }
-  return indexHTML
-    .replace(
-      '<div id="app"></div>',
-      `<div id="app" data-server-rendered="true">${appHTML}</div>${stateScript}`,
-    )
+
+  const html5Parser = await import('html5parser')
+  const ast = html5Parser.parse(indexHTML)
+  const idAttributeValue = 'app'
+  let renderedOutput: string | undefined
+
+  html5Parser.walk(ast, {
+    enter: (node) => {
+      if (!renderedOutput
+          && node?.type === html5Parser.SyntaxKind.Tag
+          && Array.isArray(node.attributes)
+          && node.attributes.length > 0
+          && node.attributes.some(attr => attr.name.value === 'id' && attr.value?.value === idAttributeValue)
+      ) {
+        const attributesStringified = [...node.attributes.map(({ name: { value: name }, value }) => `${name}="${value!.value}"`)].join(' ')
+        const indexHTMLBefore = indexHTML.slice(0, node.start)
+        const indexHTMLAfter = indexHTML.slice(node.end)
+        renderedOutput = `${indexHTMLBefore}<${node.name} ${attributesStringified} data-server-rendered="true">${appHTML}</${node.name}>${stateScript}${indexHTMLAfter}`
+      }
+    },
+  })
+
+  if (!renderedOutput)
+    throw new Error(`Could not find a tag with id="${idAttributeValue}" to replace it with server-side rendered HTML`)
+
+  return renderedOutput
 }
 
 async function formatHtml(html: string, formatting: ViteSSGOptions['formatting']) {


### PR DESCRIPTION
As discussed in #118, adding a class to `<div id="app"></div>` will break rendering.

In #183 an error is thrown, if e. g. a class is added to the div, so the user gets notified he should not do that, but the problem still persists.

This PR aims to solve this.

The implementation:
* adds [html5Parser](https://www.npmjs.com/package/html5parser) as dependency for parsing html (I am open to use another parser, this one seemed to be fast and [small](https://bundlephobia.com/package/html5parser), I could not find an API for an AST with line numbers in the original string html with JSDOM)
* imports parser, parses html and walks ast **only if string div id="app" could not be found**
* inserts in first match of id="app" the rendered content
* leaves attributes on match untouched, only adds `data-server-rendered="true"`
* still throws an error if no match for id="app" could be found
