### PR TITLE
feat: support specifying included routes in server entry file

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,34 @@ export default {
 }
 ```
 
+Alternatively, you may export the `includedRoutes` hook from your server entry file. This will be necessary if fetching your routes requires the use of environment variables managed by Vite. 
+
+```ts
+// main.ts
+
+import { ViteSSG } from 'vite-ssg'
+import App from './App.vue'
+
+export const createApp = ViteSSG(
+  App,
+  { routes },
+  ({ app, router, initialState }) => {
+    // ...
+  },
+)
+export async function includedRoutes(paths, routes) {
+  // Sensitive key is managed by Vite - this would not be available inside 
+  // vite.config.js as it runs before the environment has been populated.
+  const apiClient = new MyApiClient(import.meta.env.MY_API_KEY) 
+
+  return routes.flatMap(route => {
+    return route.name === 'Blog'
+      ? (await apiClient.fetchBlogSlugs()).map(slug => `/blog/${slug}`)
+      : route.path
+  })
+}
+```
+
 ## Comparsion
 
 ### Use [Vitepress](https://github.com/vuejs/vitepress) when you want:

--- a/README.md
+++ b/README.md
@@ -361,11 +361,13 @@ export async function includedRoutes(paths, routes) {
   // vite.config.js as it runs before the environment has been populated.
   const apiClient = new MyApiClient(import.meta.env.MY_API_KEY) 
 
-  return routes.flatMap(route => {
-    return route.name === 'Blog'
-      ? (await apiClient.fetchBlogSlugs()).map(slug => `/blog/${slug}`)
-      : route.path
-  })
+  return Promise.all(
+    routes.flatMap(async route => {
+      return route.name === 'Blog'
+        ? (await apiClient.fetchBlogSlugs()).map(slug => `/blog/${slug}`)
+        : route.path
+    })
+  )
 }
 ```
 

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -45,7 +45,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
     entry = await detectEntry(root),
     formatting = 'none',
     crittersOptions = {},
-    includedRoutes = DefaultIncludedRoutes,
+    includedRoutes: configIncludedRoutes = DefaultIncludedRoutes,
     onBeforePageRender,
     onPageRendered,
     onFinished,
@@ -102,10 +102,10 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
 
   const _require = createRequire(import.meta.url)
 
-  const { createApp }: { createApp: CreateAppFactory } = format === 'esm'
+  const { createApp, includedRoutes: serverEntryIncludedRoutes }: { createApp: CreateAppFactory; includedRoutes: ViteSSGOptions['includedRoutes'] } = format === 'esm'
     ? await import(serverEntry)
     : _require(serverEntry)
-
+  const includedRoutes = serverEntryIncludedRoutes || configIncludedRoutes
   const { routes } = await createApp(false)
 
   let routesPaths = includeAllRoutes


### PR DESCRIPTION
Adds support for specifying `includedRoutes` from server entry file. Support for specifying this from the config has been maintained - there are just two ways of supplying this information now.

Reasoning: it is difficult to perform more complex data fetching from inside the config file. This is primarily due to the fact that data fetching often makes use of sensitive keys and the main place one puts this kind of configuration is in the env config. Vite has a documented convention for env management which makes management of things like API keys nice and secure, but we cannot benefit from any of this from inside the vite config file, as the config file runs before the environment has been populated. Consider the following:

```javascript
async function includedRoutes(paths, routes) {
  return Promise.all(routes.flatMap(route => {
    switch (route.name) {
      case "Blog":
        return (await myApiClient(import.meta.env.MY_API_KEY) // this value will not be populated if run within vite config!
          .fetchBlogSlugs())
          .map(slug => `/blog/${slug}`)
      default:
         return [];
    }
  })
}
```

In order to make this function work, we need it to be imported within a file that gets processed by Vite. To me, the server entry file made the most sense. So now, instead of specifying includedRoutes in the vite config, we can export it from the server entry file alongside `createApp`.

