### PR TITLE
Use the default version for the router

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Static-site generation for Vue 3 on Vite.
 > **This library requires Node.js version >= 14**
 
 <pre>
-<b>npm i -D vite-ssg</b> <em>vue-router@next @vueuse/head</em>
+<b>npm i -D vite-ssg</b> <em>vue-router @vueuse/head</em>
 </pre>
 
 ```diff


### PR DESCRIPTION
Now the `next` tag is not necessary