### PR TITLE
fix: import jsdomGlobal using _require

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -123,8 +123,7 @@ export async function build(cliOptions: Partial<ViteSSGOptions> = {}) {
     console.log(`${gray('[vite-ssg]')} ${blue('Critical CSS generation enabled via `critters`')}`)
 
   if (mock) {
-    // @ts-expect-error dynamic import
-    const jsdomGlobal = (await import('./jsdomGlobal')).default
+    const jsdomGlobal = _require('./jsdomGlobal').default
     jsdomGlobal()
   }
 


### PR DESCRIPTION
Hello, I've been trying to ssg some components whose need browser api mock, but found this error: TypeError: jsdomGlobal is not a function.

https://github.com/antfu/vite-ssg/blob/31cab804fb4072006c323abcbf0e50a468fe6a80/src/node/build.ts#L127
After some investigation I realized that it seems the line above is importing jsdom in an unusual way

I was able to build the project by adding ".default" once again at the end, or by importing it with _require() instead.

```
const jsdomGlobal = (await import('./jsdomGlobal')).default.default
or
const jsdomGlobal = _require('./jsdomGlobal')
```

I'm not sure if the solution I'm proposing has some drawback or if there's a better approach, but it's all that I could come up with. Hope it helps