### PR TITLE
refactor: remove critters fs import workaround

### DIFF
--- a/src/node/critical.ts
+++ b/src/node/critical.ts
@@ -5,20 +5,7 @@ export async function getCritters(outDir: string, options: Options = {}): Promis
   try {
     const CrittersClass = (await import('critters')).default
 
-    // temporary workaround for: https://github.com/GoogleChromeLabs/critters/issues/94
-    const fs = await import('fs')
-
-    // Critters.readFile() somehow accepts this.fs and uses it instead of require('fs'). The latter throws an error, because require() is not available in ESM.
-    class CrittersClassWithFS extends CrittersClass {
-      fs: typeof fs
-
-      constructor(...args: ConstructorParameters<typeof CrittersClass>) {
-        super(...args)
-        this.fs = fs
-      }
-    }
-
-    return new CrittersClassWithFS({
+    return new CrittersClass({
       path: outDir,
       logLevel: 'warn',
       external: true,


### PR DESCRIPTION
The `fs` module is imported as ES module since [critters-0.0.16](https://github.com/GoogleChromeLabs/critters/commit/46f983fbed18f19a3679aa39029bb6ec4df44956). Time to drop this workaround.

Related commit: https://github.com/GoogleChromeLabs/critters/commit/ec6e1443a75e915e81f4e4ee423cb149c2ae1f50