### PR TITLE
fix: export node type

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "*": {
       "single-page": [
         "dist/client/single-page.d.ts"
+      ],
+      "node": [
+        "dist/node.d.ts"
       ]
     }
   },


### PR DESCRIPTION
I can not get type by `vite-ssg/node`.
When i add `"node": ["dist/node.d.ts"]`, it works.