### PR TITLE
Feat/add alias paths to generated routes

### DIFF
--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -14,38 +14,36 @@ export function routesToPaths(routes?: RouteRecordRaw[]) {
   if (!routes)
     return ['/']
 
-    const pathsSet = new Set();
+  const pathsSet: Set<string> = new Set()
 
-    const getPath:string = (prefix: string, path: string) => (prefix && !path.startsWith('/')
-      ? `${prefix}/${path}` : path);
-  
-    const pathWitPrefix:string[] = (prefixes:string[], paths:string[]) => paths
-      .flatMap((path:string) => prefixes
-        .map((prefix:string) => getPath(prefix, path)));
-  
-    const getPaths = (routes:RouteRecordRaw[], prefixes:string[] = ['']) => {
-      const tempPrefixes:string[] = prefixes.map((prefix:string) => prefix.replace(/\/$/g, ''));
-  
-      routes.forEach((route:RouteRecordRaw) => {
-        const generatedPaths:string[] = [];
-  
-        if (route.path) {
-          generatedPaths.push(...pathWitPrefix(tempPrefixes, [route.path]));
-        }
-  
-        if (Array.isArray(route.alias)) {
-          generatedPaths.push(...pathWitPrefix(tempPrefixes, route.alias));
-        }
-  
-        generatedPaths.forEach((generatedPath) => pathsSet.add(generatedPath));
-  
-        if (Array.isArray(route.children)) {
-          getPaths(route.children, generatedPaths);
-        }
-      });
-    };
-  
-    getPaths(allRoutes);
-  
-    return [...pathsSet];
+  const getPath = (prefix: string, path: string): string => (prefix && !path.startsWith('/')
+    ? `${prefix}/${path}`
+    : path)
+
+  const pathWitPrefix = (prefixes: string[], paths: string[]): string[] => paths
+    .flatMap((path: string) => prefixes
+      .map((prefix: string) => getPath(prefix, path)))
+
+  const getPaths = (routes: RouteRecordRaw[], prefixes: string[] = ['']) => {
+    const tempPrefixes: string[] = prefixes.map((prefix: string) => prefix.replace(/\/$/g, ''))
+
+    routes.forEach((route) => {
+      const generatedPaths: string[] = []
+
+      if (route.path)
+        generatedPaths.push(...pathWitPrefix(tempPrefixes, [route.path]))
+
+      if (Array.isArray(route.alias))
+        generatedPaths.push(...pathWitPrefix(tempPrefixes, route.alias))
+
+      generatedPaths.forEach(generatedPath => pathsSet.add(generatedPath))
+
+      if (Array.isArray(route.children))
+        getPaths(route.children, generatedPaths)
+    })
+  }
+
+  getPaths(routes)
+
+  return [...pathsSet]
 }


### PR DESCRIPTION
Currently Vite SSG can not crowd route alias on build time. I think it's important to have routes alises with different languages. I have tried to solve this problem, with this changes Vite SSG will create new path for every alias in route.