### PR TITLE
fix: absolute `__file` paths leaking into production bundle

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -28,7 +28,7 @@ function DefaultIncludedRoutes(paths: string[], _routes: Readonly<RouteRecordRaw
 
 export async function build(ssgOptions: Partial<ViteSSGOptions> = {}, viteConfig: InlineConfig = {}) {
   const mode = process.env.MODE || process.env.NODE_ENV || ssgOptions.mode || 'production'
-  const config = await resolveConfig(viteConfig, 'build', mode)
+  const config = await resolveConfig(viteConfig, 'build', mode, mode)
 
   const cwd = process.cwd()
   const root = config.root || cwd


### PR DESCRIPTION
### Description

vite [recently changed](https://github.com/vitejs/vite/pull/10996/files#diff-11e17761d4ecfee8f8fde15c6d79b7bc0260176396a30dfd8e6f6bbaf5af4745R385) the signature for `resolveConfig()` to take a 4th argument `defaultNodeEnv`, which [by default is set to `development`](https://github.com/vitejs/vite/pull/10996/files#diff-11e17761d4ecfee8f8fde15c6d79b7bc0260176396a30dfd8e6f6bbaf5af4745R376).

Since this argument is not added [when `resolveConfig` is called](https://github.com/antfu/vite-ssg/blob/main/src/node/build.ts#L31) in vite-ssg, it causes [`NODE_ENV` to get set to `development`](https://github.com/vitejs/vite/pull/10996/files#diff-11e17761d4ecfee8f8fde15c6d79b7bc0260176396a30dfd8e6f6bbaf5af4745R385). 

n turn, this [triggers `vite-plugin-vue` to consider this a development build](https://github.com/vitejs/vite-plugin-vue/blob/abdf5f4f32d02af641e5f60871bde14535569b1e/packages/plugin-vue/src/index.ts#L115), inserting [absolute file paths](https://github.com/vitejs/vite-plugin-vue/blob/abdf5f4f32d02af641e5f60871bde14535569b1e/packages/plugin-vue/src/main.ts#L115) into the bundle. 

This PR adds the correct `defaultNodeEnv` so `NODE_ENV` is correctly set to `production` during a production build. 

(Note: vite does [the exact same](https://github.com/vitejs/vite/pull/10996/files#diff-aa53520bfd53e6c24220c44494457cc66370fd2bee513c15f9be7eb537a363e7R455) when calling `vite build`)

### Linked Issues

#354 #349 

