### PR TITLE
fix: absolute `__file` paths still leaking when building in alternate non-development modes

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -28,7 +28,7 @@ function DefaultIncludedRoutes(paths: string[], _routes: Readonly<RouteRecordRaw
 
 export async function build(ssgOptions: Partial<ViteSSGOptions> = {}, viteConfig: InlineConfig = {}) {
   const mode = process.env.MODE || process.env.NODE_ENV || ssgOptions.mode || 'production'
-  const config = await resolveConfig(viteConfig, 'build', mode, mode)
+  const config = await resolveConfig(viteConfig, 'build', mode, mode !== 'development' ? 'production' : 'development')
 
   const cwd = process.cwd()
   const root = config.root || cwd


### PR DESCRIPTION
### Description

Add-on to #356 which fixed part of the problem, but building in alternate modes can still cause the issue. For example:

```
vite-ssg build --mode staging
```

Will correctly run a vite bundle in `staging` mode, but because of the issue detailed in #356 will also set `NODE_ENV` to `staging`, which [makes `vite-plugin-vue` think this is a development build](https://github.com/vitejs/vite-plugin-vue/blob/abdf5f4f32d02af641e5f60871bde14535569b1e/packages/plugin-vue/src/index.ts#L115) and leak `__file` paths.

If I understand correctly, `NODE_ENV` should really only ever be `production` or `development` (same as unset), so this PR sets the default `NODE_ENV` to `production` for any other `mode` except `development`.

(An alternate solution would be to do what vite does and set this to the [hardcoded string `production`](https://github.com/vitejs/vite/pull/10996/files#diff-aa53520bfd53e6c24220c44494457cc66370fd2bee513c15f9be7eb537a363e7R455). Either one would solve the problem, let me know which you'd prefer.)

### Linked Issues

#354 #349  