### PR TITLE
fix: the --base option not work

### DIFF
--- a/examples/multiple-pages-pwa/src/main.ts
+++ b/examples/multiple-pages-pwa/src/main.ts
@@ -2,4 +2,7 @@ import { ViteSSG } from 'vite-ssg'
 import App from './App.vue'
 import routes from '~pages'
 
-export const createApp = ViteSSG(App, { routes })
+export const createApp = ViteSSG(App, {
+  base: import.meta.env.BASE_URL,
+  routes,
+})

--- a/examples/multiple-pages-with-store/src/main.ts
+++ b/examples/multiple-pages-with-store/src/main.ts
@@ -7,7 +7,10 @@ import routes from '~pages'
 
 export const createApp = ViteSSG(
   App,
-  { routes },
+  {
+    base: import.meta.env.BASE_URL,
+    routes,
+  },
   ({ app, router, initialState }) => {
     const pinia = createPinia()
     app.use(pinia)

--- a/examples/multiple-pages/.env
+++ b/examples/multiple-pages/.env
@@ -1,0 +1,1 @@
+VITE_ENV_MODE=default

--- a/examples/multiple-pages/.env.ssg
+++ b/examples/multiple-pages/.env.ssg
@@ -1,0 +1,1 @@
+VITE_ENV_MODE=ssg

--- a/examples/multiple-pages/package.json
+++ b/examples/multiple-pages/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "scripts": {
     "dev": "cross-env DEBUG=vite-ssg:* vite",
-    "build": "cross-env DEBUG=vite-ssg:* vite-ssg build",
-    "serve": "vite preview"
+    "build": "cross-env DEBUG=vite-ssg:* vite-ssg build --base /ssg-base/ --mode ssg",
+    "serve": "vite preview --base /ssg-base/"
   },
   "dependencies": {
     "@unhead/vue": "^1.1.28",

--- a/examples/multiple-pages/src/App.vue
+++ b/examples/multiple-pages/src/App.vue
@@ -1,6 +1,11 @@
+<script setup lang="ts">
+const envMode = import.meta.env.VITE_ENV_MODE
+</script>
+
 <template>
   <main>
     <router-view />
+    <pre>VITE_ENV_MODE:{{ envMode }}</pre>
   </main>
 </template>
 

--- a/examples/multiple-pages/src/entry.ts
+++ b/examples/multiple-pages/src/entry.ts
@@ -2,4 +2,7 @@ import { ViteSSG } from 'vite-ssg'
 import App from './App.vue'
 import routes from '~pages'
 
-export const createApp = ViteSSG(App, { routes })
+export const createApp = ViteSSG(App, {
+  base: import.meta.env.BASE_URL,
+  routes,
+})

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -27,8 +27,9 @@ function DefaultIncludedRoutes(paths: string[], _routes: Readonly<RouteRecordRaw
 }
 
 export async function build(ssgOptions: Partial<ViteSSGOptions> = {}, viteConfig: InlineConfig = {}) {
-  const mode = process.env.MODE || process.env.NODE_ENV || ssgOptions.mode || 'production'
-  const config = await resolveConfig(viteConfig, 'build', mode, mode)
+  const nodeEnv = process.env.NODE_ENV || 'production'
+  const mode = ssgOptions.mode || process.env.MODE || nodeEnv
+  const config = await resolveConfig(viteConfig, 'build', mode, nodeEnv)
 
   const cwd = process.cwd()
   const root = config.root || cwd
@@ -51,6 +52,7 @@ export async function build(ssgOptions: Partial<ViteSSGOptions> = {}, viteConfig
     format = 'esm',
     concurrency = 20,
     rootContainerId = 'app',
+    base,
   }: ViteSSGOptions = Object.assign({}, config.ssgOptions || {}, ssgOptions)
 
   if (fs.existsSync(ssgOut))
@@ -59,6 +61,7 @@ export async function build(ssgOptions: Partial<ViteSSGOptions> = {}, viteConfig
   // client
   buildLog('Build for client...')
   await viteBuild(mergeConfig(viteConfig, {
+    base,
     build: {
       ssrManifest: true,
       rollupOptions: {
@@ -82,6 +85,7 @@ export async function build(ssgOptions: Partial<ViteSSGOptions> = {}, viteConfig
   process.env.VITE_SSG = 'true'
   const ssrEntry = await resolveAlias(config, entry)
   await viteBuild(mergeConfig(viteConfig, {
+    base,
     build: {
       ssr: ssrEntry,
       outDir: ssgOut,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,11 @@ export interface ViteSSGOptions {
   mode?: string
 
   /**
+   * Vite public base path.
+   */
+  base?: string
+
+  /**
    * Directory style of the output directory.
    *
    * flat: `/foo` -> `/foo.html`


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I noticed that vite-ssg build provides the `--base` option, but I found that it doesn't work as expected when I tried to use it.

Here are the tests I conducted after fixing this issue:

- Set `base` in vite.config.ts and perform a build to confirm the result.
- Set `ssgOptions.base` in vite.config.ts and perform a build to confirm the result.
- Add `--base` to vite-ssg build command and perform a build to confirm the result.
- Add `--mode` to vite-ssg build command and perform a build to confirm the result.
- Add both `--mode` and `--base` to vite-ssg build command and perform a build to confirm the result.
- Add `NODE_ENV` and `--mode` to vite-ssg build command and perform a build to confirm the result.

### Linked Issues

#339 #340 #341 