### PR TITLE
fix: update critters peer dependency to version 0.0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "release": "bumpp && npm publish"
   },
   "peerDependencies": {
-    "critters": "^0.0.16",
+    "critters": "^0.0.20",
     "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0",
     "vue": "^3.2.10",
     "vue-router": "^4.0.1"


### PR DESCRIPTION
### Description

This change updates critters to version 0.0.20 in the peer dependencies section of the `package.json`. This is needed so that projects that are using vite-ssg can also update critters to version 0.0.20 in their dev dependencies.

This change also means that the same version of critters is now used in both the dev dependencies and peer dependencies of vite-ssg.

### Linked Issues

#119
#370
