### PR TITLE
fix: renderHTML indexHTML.replace when appHTML with $

### DIFF
--- a/examples/single-page/src/App.vue
+++ b/examples/single-page/src/App.vue
@@ -15,6 +15,8 @@ const store = useRootStore()
 
   <h3>Initial State:</h3>
   <pre>{{ store.user }}</pre>
+  
+  <a href="https://github.com/antfu/vite-ssg" aria-label="Permalink to &quot;Usage `^`, `$`&quot;"></a>
 </template>
 
 <style>

--- a/examples/single-page/src/App.vue
+++ b/examples/single-page/src/App.vue
@@ -15,8 +15,8 @@ const store = useRootStore()
 
   <h3>Initial State:</h3>
   <pre>{{ store.user }}</pre>
-  
-  <a href="https://github.com/antfu/vite-ssg" aria-label="Permalink to &quot;Usage `^`, `$`&quot;"></a>
+
+  <a href="https://github.com/antfu/vite-ssg" aria-label="Permalink to &quot;Usage `^`, `$`&quot;" />
 </template>
 
 <style>

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -279,7 +279,7 @@ async function renderHTML({
     return indexHTML
       .replace(
         container,
-        `<div id="${rootContainerId}" data-server-rendered="true">${appHTML}</div>${stateScript}`,
+        () => `<div id="${rootContainerId}" data-server-rendered="true">${appHTML}</div>${stateScript}`,
       )
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When <code>$\`</code> in `appHTML`, `indexHTML.replace` (renderHTML) will result in an abnormal replacement.

> [Specifying a string as the replacement | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement)

![image](https://github.com/antfu/vite-ssg/assets/25154432/97a1b89b-7152-491b-807c-9ac0e5c9da26)

https://github.com/antfu/vite-ssg/blob/8015d55b798fa9d5f3ebb7c79763ec7ad429a795/src/node/build.ts#L279-L283

In order for it not to be affected by special rules, we need to convert it into a function.

```ts
() => `<div id="${rootContainerId}" data-server-rendered="true">${appHTML}</div>${stateScript}`
```

### Linked Issues

https://github.com/YunYouJun/valaxy/issues/295

It can be reproduced in the vite-ssg examples.

```html
<a href="https://github.com/antfu/vite-ssg" aria-label="Permalink to &quot;Usage `^`, `$`&quot;"></a>
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
