### PR TITLE
refactor: uses unhead/server to optimize head

### DIFF
--- a/examples/multiple-pages/index.html
+++ b/examples/multiple-pages/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vite SSG</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css" integrity="sha512-Oy18vBnbSJkXTndr2n6lDMO5NN31UljR8e/ICzVPrGpSud4Gkckb8yUpqhKuUNoE+o9gAb4O/rAxxw1ojyUVzg==" crossorigin="anonymous" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/LukeAskew/prism-github@master/prism-github.css" />
+  <meta charset="UTF-8">
+  <title>Vite SSG</title>
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
Hello 👋,

Currently, Vite SSG generates the head using a client-side hook from Unhead (`renderDOMHead`).

This means the head isn’t fully optimized for performance when the browser loads the page.

I refactored the generation process to use `transformHtmlTemplate`, which uses capo.js under the hood to optimize the page (see [capo.js rules](https://rviscomi.github.io/capo.js/user/rules/)).

For example, the output of examples/multiple-pages/dist/index.html goes from:

```html
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <link
      rel="stylesheet"
      href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css"
      integrity="sha512-Oy18vBnbSJkXTndr2n6lDMO5NN31UljR8e/ICzVPrGpSud4Gkckb8yUpqhKuUNoE+o9gAb4O/rAxxw1ojyUVzg=="
      crossorigin="anonymous"
    />
    <link
      rel="stylesheet"
      href="https://cdn.jsdelivr.net/gh/LukeAskew/prism-github@master/prism-github.css"
    />
    <title>Index Page</title>
    <meta charset="utf-8" />
    <script
      type="module"
      async
      crossorigin
      src="/ssg-base/assets/app-85d9JDTF.js"
    ></script>
    <link
      rel="stylesheet"
      crossorigin
      href="/ssg-base/assets/app-DX0qcnGS.css"
    />
    <meta property="og:title" content="Index Page" />
    <meta name="twitter:title" content="Index Page" />
```

to

```html
    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <title>Index Page</title>
    <script
      type="module"
      async
      crossorigin
      src="/ssg-base/assets/app-85d9JDTF.js"
    ></script>
    <link
      rel="stylesheet"
      href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css"
      integrity="sha512-Oy18vBnbSJkXTndr2n6lDMO5NN31UljR8e/ICzVPrGpSud4Gkckb8yUpqhKuUNoE+o9gAb4O/rAxxw1ojyUVzg=="
      crossorigin="anonymous"
    />
    <link
      rel="stylesheet"
      href="https://cdn.jsdelivr.net/gh/LukeAskew/prism-github@master/prism-github.css"
    />
    <link
      rel="stylesheet"
      crossorigin
      href="/ssg-base/assets/app-DX0qcnGS.css"
    />
    <meta property="og:title" content="Index Page" />
    <meta name="twitter:title" content="Index Page" />
```

<details><summary>Patch</summary>
<p>

```diff
diff --git a/dist/shared/vite-ssg.0i5mAeat.mjs b/dist/shared/vite-ssg.0i5mAeat.mjs
index 6c74327c9cf19cdce335627d2f5021f89198b74a..0827a546143d9d401cd9334278fbd3e51511c3d2 100644
--- a/dist/shared/vite-ssg.0i5mAeat.mjs
+++ b/dist/shared/vite-ssg.0i5mAeat.mjs
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import { resolve, isAbsolute, parse, join, dirname } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
-import { renderDOMHead } from '@unhead/dom';
+import { transformHtmlTemplate  } from '@unhead/vue/server';
 import { gray, yellow, blue, dim, cyan, red, green } from 'ansis';
 import { JSDOM } from 'jsdom';
 import { resolveConfig, build as build$1, mergeConfig } from 'vite';
@@ -1337,13 +1337,14 @@ async function build(ssgOptions = {}, viteConfig = {}) {
         });
         const jsdom = new JSDOM(renderedHTML);
         renderPreloadLinks(jsdom.window.document, ctx.modules || /* @__PURE__ */ new Set(), ssrManifest);
-        if (head)
-          await renderDOMHead(head, { document: jsdom.window.document });
         const html = jsdom.serialize();
         let transformed = await onPageRendered?.(route, html, appCtx) || html;
         if (beasties)
           transformed = await beasties.process(transformed);
-        const formatted = await formatHtml(transformed, formatting);
+        let optimized = html
+        if (head)
+          optimized = await transformHtmlTemplate(head, transformed)
+        const formatted = await formatHtml(optimized, formatting);
         const relativeRouteFile = `${(route.endsWith("/") ? `${route}index` : route).replace(/^\//g, "")}.html`;
         const filename = await prepareHtmlFileName(
           dirStyle === "nested" ? join(route.replace(/^\//g, ""), "index.html") : relativeRouteFile,
```

</p>
</details> 